### PR TITLE
fix FTS skill: query_string takes no field/fields key — use Lucene qualifiers

### DIFF
--- a/skills/pinecone-full-text-search/SKILL.md
+++ b/skills/pinecone-full-text-search/SKILL.md
@@ -69,7 +69,7 @@ resp = idx.documents.search(
 | `dense_vector` | `field` (dense_vector), `values` (list of floats) | Semantic / mood / topic ranking |
 | `sparse_vector` | `field` (sparse_vector), `sparse_values` ({indices, values}) | Custom sparse-encoder ranking |
 
-`text` / `dense_vector` / `sparse_vector` use singular `field`. `query_string` takes **no** `field` or `fields` key — passing either returns a `400`; scope fields inside the query with `fieldname:value` qualifiers. `sparse_vector` uses `sparse_values` (NOT `values`) — distinct from dense.
+`text` / `dense_vector` / `sparse_vector` use singular `field`. `query_string` takes **no** `field` or `fields` key — passing either returns a `400`; scope fields inside the query with `fieldname:value` qualifiers (unqualified terms search every text-searchable field). `sparse_vector` uses `sparse_values` (NOT `values`) — distinct from dense.
 
 **Filter operators by field type:**
 

--- a/skills/pinecone-full-text-search/SKILL.md
+++ b/skills/pinecone-full-text-search/SKILL.md
@@ -56,7 +56,7 @@ resp = idx.documents.search(
 
 **Key rules** (the server enforces these; following them locally keeps the agent loop tight):
 
-- `score_by` is a list of clauses, but **exactly one scoring type per request** (server rejects mixed types). Multi-field BM25 is the one exception: multiple `text` clauses, or one `query_string` with `fields: [...]`. To combine BM25 + dense signals, restrict the dense search with a text-match filter (`$match_all` / `$match_phrase` / `$match_any`); do NOT mix scoring types in `score_by`.
+- `score_by` is a list of clauses, but **exactly one scoring type per request** (server rejects mixed types). Multi-field BM25 is the one exception: multiple `text` clauses, or one `query_string` whose expression spans fields (`title:(q) OR body:(q)`). To combine BM25 + dense signals, restrict the dense search with a text-match filter (`$match_all` / `$match_phrase` / `$match_any`); do NOT mix scoring types in `score_by`.
 - `filter` keys are field names (must exist in schema and be filterable) OR logical operators (`$and`, `$or`, `$not`). Field values are operator dicts (`{"$gt": 5}`, NOT bare values).
 - `include_fields` is required on every call. Pass `["*"]` for all stored fields, `[]` for ids+score only, or a list of names. Some SDK builds 400/422 if it's omitted.
 
@@ -65,11 +65,11 @@ resp = idx.documents.search(
 | `type` | Required keys | When to pick this |
 |---|---|---|
 | `text` | `field` (string FTS), `query` | Open-ended keyword search; BM25 ranking on one field |
-| `query_string` | `query` (Lucene), `fields` optional | Lucene boost (`^N`), proximity (`~N`), cross-field boolean, phrase prefix |
+| `query_string` | `query` (Lucene) | Lucene boost (`^N`), proximity (`~N`), cross-field boolean, phrase prefix |
 | `dense_vector` | `field` (dense_vector), `values` (list of floats) | Semantic / mood / topic ranking |
 | `sparse_vector` | `field` (sparse_vector), `sparse_values` ({indices, values}) | Custom sparse-encoder ranking |
 
-`text` / `dense_vector` / `sparse_vector` use singular `field`. Only `query_string` accepts a `fields` array (and also accepts singular `field` as an alias). `sparse_vector` uses `sparse_values` (NOT `values`) — distinct from dense.
+`text` / `dense_vector` / `sparse_vector` use singular `field`. `query_string` takes **no** `field` or `fields` key — passing either returns a `400`; scope fields inside the query with `fieldname:value` qualifiers. `sparse_vector` uses `sparse_values` (NOT `values`) — distinct from dense.
 
 **Filter operators by field type:**
 
@@ -336,9 +336,9 @@ for m in resp.matches:
 - **Document operations: search supports `filter`, fetch and delete do not.** Fetch is **ID-only** (`POST /documents/fetch` with `ids: [...]`); delete accepts only `ids` or `delete_all: true`. To act on a metadata expression, search first to collect IDs, then fetch or delete those IDs.
 - **Namespaces auto-create on first upsert.** Pass any namespace string to `documents.upsert` / `batch_upsert` and the namespace is created on the fly; documents from different namespaces are fully isolated. Use `"__default__"` if you don't need partitioning. **Caveat:** the namespace management endpoints (`POST /namespaces`, `GET /namespaces`, `DELETE /namespaces/{namespace}`) and `describe_index_stats` are NOT yet supported on indexes with document schemas — you can write to a namespace, you just can't list / delete them via the API yet.
 - **Document and request size limits** (preview): per-document max **2 MB**; per-request max **2 MB and 1000 documents**; per FTS-enabled `string` field max **100 KB and 10,000 tokens** (tokens > 256 bytes are truncated by the analyzer); per-document filterable metadata (everything *not* in an FTS field) max **40 KB**. A schema can declare up to **100 FTS string fields**. For long-prose corpora, chunk before ingest — see `references/ingestion.md`.
-- **`score_by` clause shape — singular `field` is canonical for `text`/`dense_vector`/`sparse_vector`; only `query_string` takes a `fields` array.**
+- **`score_by` clause shape — singular `field` is required for `text`/`dense_vector`/`sparse_vector`; `query_string` takes no field key at all.**
     - `text`: `{"type":"text", "field":"<fts_field>", "query":"<terms>"}`.
-    - `query_string`: `{"type":"query_string", "query":"<lucene>", "fields":["<a>","<b>"]}` (the optional `fields` array; `query_string` also accepts a bare `"fields":"body"` string and the legacy `"field":"body"` as an alias).
+    - `query_string`: `{"type":"query_string", "query":"<lucene>"}` — no `field`/`fields` key (passing either returns a `400`). Target specific fields with Lucene qualifiers inside the query string: `fieldname:value` or `fieldname:(multi word value)`.
     - `dense_vector`: `{"type":"dense_vector", "field":"<dense_field>", "values":[/*floats*/]}`.
     - `sparse_vector`: `{"type":"sparse_vector", "field":"<sparse_field>", "sparse_values":{"indices":[...],"values":[...]}}` — note `sparse_values` (NOT `values`) for sparse clauses.
 - **Single-term prefix wildcards aren't supported.** `auto*` doesn't work in `query_string`; use phrase prefix (`"machine lea"*` — phrase must contain at least two terms, last term is matched as prefix).

--- a/skills/pinecone-full-text-search/references/querying.md
+++ b/skills/pinecone-full-text-search/references/querying.md
@@ -7,7 +7,7 @@ All reads on a Pinecone preview document index go through `idx.documents.search(
 A single `documents.search` request ranks by **one** scoring type. `score_by` accepts a list, but every entry must share a type:
 
 - Multiple `text` clauses (one per field) — that's how multi-field BM25 works.
-- A single `query_string` clause (which can target multiple fields via `fields: [...]` or inline `field:term` syntax inside the Lucene expression).
+- A single `query_string` clause (which can target multiple fields via inline `field:term` qualifiers in the Lucene expression).
 - `dense_vector` clauses must appear alone.
 - `sparse_vector` clauses must appear alone.
 - You **cannot** blend types — no `text` + `query_string`, no `text` + `dense_vector`, no cross-type mix. The server rejects it.
@@ -29,7 +29,7 @@ resp = idx.documents.search(
 
 Tokenizes `query` with the field's analyzer, scores each matching document with a BM25 ranker over the inverted index, returns the top `top_k`. Multiple terms use **OR semantics** — documents matching any token participate, those matching more / rarer tokens score higher. Phrase constraints (adjacent words in order) are **not** supported here — use `query_string` with quotes, or a `$match_phrase` filter, for phrase semantics.
 
-`field` is a **single string** (singular) naming an FTS-enabled `string` field — `text` clauses are scoped to one field at a time. For multi-field BM25, pass several `text` clauses (one per field) or use a `query_string` clause with a `fields` array (see Multi-field BM25 below).
+`field` is a **single string** (singular) naming an FTS-enabled `string` field — `text` clauses are scoped to one field at a time. For multi-field BM25, pass several `text` clauses (one per field) or use a `query_string` clause with inline field qualifiers (see Multi-field BM25 below).
 
 ### 2. `query_string` — Lucene syntax (boolean / phrase / boost / slop / prefix / cross-field)
 
@@ -60,12 +60,11 @@ Supported operators (full table in the public-preview docs, summarized here):
 | Phrase prefix  | `"… word"*`         | `body:("james w"*)`               |
 | Cross-field    | `f1:(…) OR f2:(…)`  | `title:(quantum) OR body:(quantum machine)` |
 
-**Cross-field clauses** are unique to `query_string` — they let one expression target multiple text-searchable fields with their own sub-clauses. Optionally pass a top-level `fields` array on the clause to restrict scope; omitted, the query runs against every text-searchable field in the schema.
+**Cross-field clauses** are unique to `query_string` — they let one expression target multiple text-searchable fields with their own sub-clauses. Field scope lives inside the query string itself, via `fieldname:value` / `fieldname:(multi word value)` qualifiers; unqualified terms run against every text-searchable field in the schema. The clause takes no `field` or `fields` key — passing either returns a `400`.
 
 ```python
 score_by=[{
     "type": "query_string",
-    "fields": ["title", "body"],            # optional; restricts the query
     "query": 'title:(quantum)^2 OR body:("machine learning")',
 }]
 ```


### PR DESCRIPTION
Closes #11.

The FTS skill taught an optional `fields` array on `query_string` clauses — and claimed a bare `"fields": "body"` string and a legacy `"field"` alias were also accepted. Per the current [full-text search docs](https://docs.pinecone.io/guides/search/full-text-search) (`2026-01.alpha`):

> `query_string` does not accept a `field` or `fields` parameter. Passing either returns a `400` error. Use Lucene field qualifiers in the query string itself to target specific fields: `fieldname:value` or `fieldname:(multi word value)`.

One heads-up for review: the docs page is currently inconsistent with itself — its query-syntax comparison table still lists `fields` as "Optional" for `query_string`, contradicting the warning quoted above. This PR follows the warning, which is the recently updated statement and the one issue #11 quotes.

This updates every spot that taught the parameter: five in `SKILL.md` (the key-rules bullet, the clause-shapes table row and its prose note, and the canonical clause-shape bullet plus its header) and three in `references/querying.md` (the one-scoring-type rule, the multi-field note, and the cross-field section, whose example drops its `"fields": ["title", "body"]` line). Field targeting now consistently points at inline Lucene qualifiers.

It also resolves a pre-existing inconsistency: the multi-field note pointed at "Multi-field BM25 below" for the `fields` array, but that section's Option B already used inline qualifiers — the pointer now matches its target.

Verification: after the change, grepping the skill for `fields` (excluding `include_fields`, a real parameter) matches no remaining `query_string` parameter guidance; `include_fields` usage is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
