### PR TITLE
add match-all browse pattern (query: "*") to FTS skill

### DIFF
--- a/skills/pinecone-full-text-search/SKILL.md
+++ b/skills/pinecone-full-text-search/SKILL.md
@@ -218,6 +218,7 @@ Map user prompt cues to API shapes. Read top-down — identify the cue, copy the
 | User prompt cue | API shape |
 |---|---|
 | Open-ended keywords ("articles about machine learning", search-bar query) | `score_by=[{"type": "text", "field": "<field>", "query": "<terms>"}]` — BM25 token-OR |
+| Everything, no query ("show all results", initial view before the user types) | `score_by=[{"type": "query_string", "query": "*"}]` — returns `top_k` docs in arbitrary order, not ranked. Don't emulate with a sentinel field |
 | Exact phrase, drives ranking ("rank by 'beautifully written'") | `score_by=[{"type": "query_string", "query": '<field>:("phrase here")'}]` |
 | Exact phrase, hard requirement ("must contain 'machine learning'") | `filter={"<field>": {"$match_phrase": "machine learning"}}` |
 | Required tokens, any order ("must mention TensorFlow", "must be about Illinois") | `filter={"<field>": {"$match_all": "tokens space-separated"}}` — preferred over `query_string` `+token` because it's a true hard filter, doesn't contribute to score |

--- a/skills/pinecone-full-text-search/SKILL.md
+++ b/skills/pinecone-full-text-search/SKILL.md
@@ -218,7 +218,7 @@ Map user prompt cues to API shapes. Read top-down — identify the cue, copy the
 | User prompt cue | API shape |
 |---|---|
 | Open-ended keywords ("articles about machine learning", search-bar query) | `score_by=[{"type": "text", "field": "<field>", "query": "<terms>"}]` — BM25 token-OR |
-| Everything, no query ("show all results", initial view before the user types) | `score_by=[{"type": "query_string", "query": "*"}]` — returns `top_k` docs in arbitrary order, not ranked. Don't emulate with a sentinel field |
+| Everything, no query ("show all results", initial view before the user types) | `score_by=[{"type": "query_string", "query": "*"}]` — returns `top_k` docs in arbitrary order, not ranked. Don't emulate with a dedicated match-all field |
 | Exact phrase, drives ranking ("rank by 'beautifully written'") | `score_by=[{"type": "query_string", "query": '<field>:("phrase here")'}]` |
 | Exact phrase, hard requirement ("must contain 'machine learning'") | `filter={"<field>": {"$match_phrase": "machine learning"}}` |
 | Required tokens, any order ("must mention TensorFlow", "must be about Illinois") | `filter={"<field>": {"$match_all": "tokens space-separated"}}` — preferred over `query_string` `+token` because it's a true hard filter, doesn't contribute to score |

--- a/skills/pinecone-full-text-search/references/querying.md
+++ b/skills/pinecone-full-text-search/references/querying.md
@@ -140,7 +140,7 @@ resp = idx.documents.search(
 )
 ```
 
-This returns `top_k` documents in **arbitrary order** — it is not relevance-ranked keyword search. A bare `*` as the entire query is the one exception to the wildcard rules above (single-term prefixes like `auto*` remain unsupported). It is the documented pattern for an unfiltered listing; don't emulate it by storing a sentinel field on every document and querying against that.
+This returns `top_k` documents in **arbitrary order** — it is not relevance-ranked keyword search. A bare `*` as the entire query is an exception to the wildcard rules above (single-term prefixes like `auto*` remain unsupported). It is the documented pattern for an unfiltered listing; don't emulate it by storing a sentinel field on every document and querying against that.
 
 ## Filtering
 

--- a/skills/pinecone-full-text-search/references/querying.md
+++ b/skills/pinecone-full-text-search/references/querying.md
@@ -127,6 +127,21 @@ score_by=[{
 
 Both reward documents that match in multiple fields. **`2026-01.alpha` weights every contributing field equally** — there is no per-clause weight parameter. To approximate weighting, use Option B with `^N` term boosts inside the query string (`title:({q})^3 OR body:({q})`).
 
+## Match-all browse (`query: "*"`)
+
+To return documents without any query — an initial view before the user has typed anything, or "just show me everything up to N" — use a `query_string` clause with `query: "*"`:
+
+```python
+resp = idx.documents.search(
+    namespace=NAMESPACE,
+    top_k=25,
+    score_by=[{"type": "query_string", "query": "*"}],
+    include_fields=["*"],
+)
+```
+
+This returns `top_k` documents in **arbitrary order** — it is not relevance-ranked keyword search. A bare `*` as the entire query is the one exception to the wildcard rules above (single-term prefixes like `auto*` remain unsupported). It is the documented pattern for an unfiltered listing; don't emulate it by storing a sentinel field on every document and querying against that.
+
 ## Filtering
 
 Filters run **before** scoring — they shrink the candidate set, then the chosen `score_by` ranks survivors. Two families of operators.


### PR DESCRIPTION
Closes #10.

When asked for an unfiltered listing ("show all results up to top_k"), the skill offered nothing, so agents invent workarounds — in the issue's case, storing a sentinel field on every document and querying against it. The docs' pattern:

> To populate an initial view before a user enters a query, use `query_string` with `query: "*"`. This returns `top_k` documents in an arbitrary order; it is not relevance-ranked keyword search.

This adds the pattern in two places agents map prompt cues to query shapes: a "Match-all browse" section in `references/querying.md` (runnable example, the arbitrary-order caveat, and a note that a bare `*` is the one exception to the no-wildcards rule) and a row in `SKILL.md`'s prompt-cue table — each warning against the sentinel-field workaround the issue observed.

One deliberate divergence from the issue's expected snippet: it showed a `text` clause with `query: "*"`, but the docs specify the `query_string` form, so that is what the skill teaches.

Composes with #14 (adjacent guidance, non-overlapping lines — verified with a test merge); whichever lands second rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
