### PR TITLE
ci: make skill sync dispatch-only

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,13 +1,9 @@
 name: Sync Skills to Plugin Repos
-# Two sync modes:
-#   push → incremental: diffs HEAD~1..HEAD, syncs only changed skill files to ALL target repos
-#   dispatch → full: syncs every file under skills/ to a chosen repo (or all repos)
+# Dispatch-only, full sync: copies every file under skills/ to a chosen repo
+# (or all repos). Incremental push-triggered sync was removed — it diffed
+# HEAD~1..HEAD under fetch-depth 2 and silently dropped older commits.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'skills/**'
   workflow_dispatch:
     inputs:
       target_repo:
@@ -17,8 +13,6 @@ on:
           - all
           - pinecone-io/pinecone-claude-code-plugin
           - pinecone-io/pinecone-cursor-plugin
-          - pinecone-io/gemini-cli-extension
-          - pinecone-io/kiro-powers
         default: all
 
 jobs:
@@ -31,10 +25,6 @@ jobs:
           - repo: 'pinecone-io/pinecone-claude-code-plugin'
             skills_dir: 'skills'
           - repo: 'pinecone-io/pinecone-cursor-plugin'
-            skills_dir: 'skills'
-          - repo: 'pinecone-io/gemini-cli-extension'
-            skills_dir: 'skills'
-          - repo: 'pinecone-io/kiro-powers'
             skills_dir: 'skills'
 
     name: Sync → ${{ matrix.target.repo }}


### PR DESCRIPTION
Removes the `push` trigger from `sync-skills.yml` and drops two targets that no
longer exist.

**Why the push trigger goes.** It diffed `HEAD~1..HEAD` under `fetch-depth: 2`, so
a merge commit that carried more than one commit of skill changes synced only the
last one. The rest were silently dropped and stayed dropped, because nothing ever
recomputed the full state.

Sync stays available via `workflow_dispatch`, which has always done a full copy
rather than an incremental diff.

**Targets removed:** `gemini-cli-extension` and `kiro-powers`. Neither is a live
sync destination.

Merging this before any content change is deliberate — it stops the current
pipeline from firing on merges while its replacement is in review.

No behaviour change to the dispatch path.
