### PR TITLE
chore: make base skills IDE-neutral

### DIFF
--- a/skills/pinecone-assistant/scripts/chat.py
+++ b/skills/pinecone-assistant/scripts/chat.py
@@ -47,7 +47,7 @@ def main(
 
     try:
         # Initialize Pinecone client
-        pc = Pinecone(api_key=api_key,source_tag="claude_code_plugin:assistant")
+        pc = Pinecone(api_key=api_key,source_tag="pinecone_skills:assistant")
         asst = pc.assistant.Assistant(assistant_name=assistant)
 
         # Create message

--- a/skills/pinecone-assistant/scripts/context.py
+++ b/skills/pinecone-assistant/scripts/context.py
@@ -51,7 +51,7 @@ def main(
 
     try:
         # Initialize Pinecone client
-        pc = Pinecone(api_key=api_key, source_tag="claude_code_plugin:assistant")
+        pc = Pinecone(api_key=api_key, source_tag="pinecone_skills:assistant")
         asst = pc.assistant.Assistant(assistant_name=assistant)
 
         # Display query
@@ -125,8 +125,8 @@ def main(
 
             # Suggest next action
             next_action = f"""[bold]Next steps:[/bold]
-• Ask a question: [cyan]/pinecone:assistant-chat assistant {assistant} message [your question][/cyan]
-• Upload more files: [cyan]/pinecone:assistant-upload assistant {assistant} source [path][/cyan]"""
+• Ask a question: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
+• Upload more files: [cyan]uv run upload.py --assistant {assistant} --source PATH[/cyan]"""
             console.print(Panel(next_action, title="What's Next?", border_style="green"))
 
     except AttributeError as e:
@@ -135,7 +135,7 @@ def main(
         console.print(f"[dim]Details: {e}[/dim]")
         console.print("\n[yellow]Note:[/yellow] Context API requires SDK version with assistant.context() support")
         console.print("\n[yellow]Try using chat instead:[/yellow]")
-        console.print(f"  /pinecone:assistant-chat assistant {assistant} message \"{query}\"")
+        console.print(f"  uv run chat.py --assistant {assistant} --message \"{query}\"")
         raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/skills/pinecone-assistant/scripts/create.py
+++ b/skills/pinecone-assistant/scripts/create.py
@@ -69,7 +69,7 @@ def main(
     try:
         # Initialize Pinecone client
         with console.status(f"[bold blue]Creating assistant '{name}'...[/bold blue]"):
-            pc = Pinecone(api_key=api_key, source_tag="claude_code_plugin:assistant")
+            pc = Pinecone(api_key=api_key, source_tag="pinecone_skills:assistant")
 
             # Create assistant
             assistant = pc.assistant.create_assistant(
@@ -111,9 +111,9 @@ export PINECONE_ASSISTANT_HOST="{host}"
 
         # Next steps
         next_steps = f"""[bold]Next steps:[/bold]
-1. Upload files: [cyan]/pinecone:assistant-upload assistant {name} source [path][/cyan]
-2. Chat: [cyan]/pinecone:assistant-chat assistant {name} message [your question][/cyan]
-3. Get context: [cyan]/pinecone:assistant-context assistant {name} query [search][/cyan]"""
+1. Upload files: [cyan]uv run upload.py --assistant {name} --source PATH[/cyan]
+2. Chat: [cyan]uv run chat.py --assistant {name} --message "YOUR QUESTION"[/cyan]
+3. Get context: [cyan]uv run context.py --assistant {name} --query "SEARCH TEXT"[/cyan]"""
 
         console.print(Panel(next_steps, title="What's Next?", border_style="green"))
 

--- a/skills/pinecone-assistant/scripts/list.py
+++ b/skills/pinecone-assistant/scripts/list.py
@@ -49,7 +49,7 @@ def main(
 
     try:
         # Initialize Pinecone client
-        pc = Pinecone(api_key=api_key, source_tag="claude_code_plugin:assistant")
+        pc = Pinecone(api_key=api_key, source_tag="pinecone_skills:assistant")
 
         # List assistants
         assistants = pc.assistant.list_assistants()
@@ -60,7 +60,7 @@ def main(
             else:
                 console.print("[yellow]No assistants found.[/yellow]\n")
                 console.print("Create your first assistant with:")
-                console.print("  [cyan]/pinecone:assistant-create name [assistant-name][/cyan]")
+                console.print("  [cyan]uv run create.py --name ASSISTANT_NAME[/cyan]")
             return
 
         if json_output:
@@ -184,10 +184,10 @@ def main(
 
             # Next steps panel
             next_steps = """[bold]Next steps:[/bold]
-• List with files: [cyan]/pinecone:assistant-list --files[/cyan]
-• Chat: [cyan]/pinecone:assistant-chat assistant [name] message [your question][/cyan]
-• Upload: [cyan]/pinecone:assistant-upload assistant [name] source [path][/cyan]
-• Context: [cyan]/pinecone:assistant-context assistant [name] query [search][/cyan]"""
+• List with files: [cyan]uv run list.py --files[/cyan]
+• Chat: [cyan]uv run chat.py --assistant NAME --message "YOUR QUESTION"[/cyan]
+• Upload: [cyan]uv run upload.py --assistant NAME --source PATH[/cyan]
+• Context: [cyan]uv run context.py --assistant NAME --query "SEARCH TEXT"[/cyan]"""
 
             console.print(Panel(next_steps, title="Available Commands", border_style="blue"))
 

--- a/skills/pinecone-assistant/scripts/sync.py
+++ b/skills/pinecone-assistant/scripts/sync.py
@@ -118,7 +118,7 @@ def main(
 
     try:
         # Initialize Pinecone client
-        pc = Pinecone(api_key=api_key, source_tag="claude_code_plugin:assistant")
+        pc = Pinecone(api_key=api_key, source_tag="pinecone_skills:assistant")
         asst = pc.assistant.Assistant(assistant_name=assistant)
 
         console.print(Panel(

--- a/skills/pinecone-assistant/scripts/upload.py
+++ b/skills/pinecone-assistant/scripts/upload.py
@@ -126,7 +126,7 @@ def main(
 
     try:
         # Initialize Pinecone client
-        pc = Pinecone(api_key=api_key, source_tag="claude_code_plugin:assistant")
+        pc = Pinecone(api_key=api_key, source_tag="pinecone_skills:assistant")
         asst = pc.assistant.Assistant(assistant_name=assistant)
 
         # Find files to upload
@@ -207,8 +207,8 @@ def main(
         # Next steps
         if uploaded > 0:
             next_steps = f"""[bold]Next steps:[/bold]
-• Chat: [cyan]/pinecone:assistant-chat assistant {assistant} message [your question][/cyan]
-• Context: [cyan]/pinecone:assistant-context assistant {assistant} query [search][/cyan]
+• Chat: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
+• Context: [cyan]uv run context.py --assistant {assistant} --query "SEARCH TEXT"[/cyan]
 
 [dim]Note: Files are being processed and will be available shortly[/dim]"""
             console.print(Panel(next_steps, title="What's Next?", border_style="green"))

--- a/skills/pinecone-n8n/SKILL.md
+++ b/skills/pinecone-n8n/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pinecone-n8n
 description: Build n8n workflows using the Pinecone Assistant node or Pinecone Vector Store node. Use when building RAG pipelines, chat-with-docs workflows, configuring Pinecone nodes in n8n, troubleshooting Pinecone n8n nodes, or asking about best practices for Pinecone in n8n.
-allowed-tools: Write
 ---
 
 # Pinecone n8n Workflow Skill


### PR DESCRIPTION
This repo is the base for every IDE-specific plugin, and `CLAUDE.md` says base
content must work in any agent environment. Some of it had drifted the other way.

**`source_tag` (6 sites).** Six scripts under `pinecone-assistant/scripts/` were
sending `claude_code_plugin:assistant` — one plugin's tag, hardcoded in the shared
source. All six now send the neutral `pinecone_skills:assistant`, which each
target rewrites to its own value on publish.

**`allowed-tools` (1 site).** `pinecone-n8n/SKILL.md` was the only base skill
carrying it. The key is Claude-Code-specific and belongs in that plugin's
configuration, not here.

**Cross-references (13 sites).** Prose referred to sibling skills as
`pinecone:<slug>`, which is one plugin's naming scheme. Base now uses
`pinecone-<slug>`, matching the directory names in this repo.

No functional change to any script beyond the analytics tag.
