### PR TITLE
chore: gitignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ docs/
 
 # macOS Finder metadata
 .DS_Store
+
+# Local secrets — never commit
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
Adds `.env` and `.env.*` to `.gitignore`.

The skills document `uv run --env-file .env` as the way to supply
`PINECONE_API_KEY` in editors that don't inherit shell variables, so anyone
following that guidance while working in this repo ends up with an API key in an
untracked file at the root. One `git add -A` away from committing it.

Ignoring it is cheap insurance.

Touches `.gitignore` only.
