### PR TITLE
fix: FTS docs referenced a SchemaBuilder method that does not exist

### DIFF
--- a/skills/pinecone-full-text-search/SKILL.md
+++ b/skills/pinecone-full-text-search/SKILL.md
@@ -267,7 +267,7 @@ schema = (
     SchemaBuilder()
     .add_string_field("body", full_text_search={"language": "en"})  # TODO: rename for your content
     .add_string_field("category", filterable=True)                   # TODO: any exact-match metadata
-    .add_integer_field("year", filterable=True)                      # TODO: any numeric filter — emits `"type": "float"` on the wire
+    .add_float_field("year", filterable=True)                        # TODO: any numeric filter — `float` is the only numeric wire type
     .build()
 )
 
@@ -323,7 +323,7 @@ for m in resp.matches:
 - **One scoring type per search request.** `score_by` accepts `text`, `query_string`, `dense_vector`, or `sparse_vector` — but a request ranks by *one* type. Multi-field BM25 is fine (pass several `text` clauses, or a single cross-field `query_string`). To combine BM25 ranking with a `dense_vector` (or `sparse_vector`) signal, restrict the dense search with a text-match `filter` operator (`$match_phrase` / `$match_all` / `$match_any`) on the lexical field, *not* by mixing types in `score_by`. The "blend a dense vector and a text clause in `score_by`" pattern is rejected by the server.
 - **Text-match filter operators are the cross-modal hinge.** `$match_phrase` (exact phrase), `$match_all` (every token, any order), `$match_any` (at least one token) are filter-side operators on `full_text_search` fields. Each takes a single string (max 128 tokens). They reuse the field's tokenizer / stemmer, compose under `$and` / `$or` / `$not`, and are the supported way to compose lexical pre-filtering with dense or sparse ranking. **Phrase slop (`"…"~N`), term boost (`^N`), and phrase prefix (`"… word"*`) are scoring-only — they live in `query_string`, not in `filter`.**
 - **Preprod backends need `additional_headers={"x-environment": "..."}` on the `Pinecone()` client.** Missing the header lands you on prod and you'll see "index not found" / empty-result symptoms that look like code bugs but aren't.
-- **`include_fields` is required on every `documents.search(...)` call.** When omitted, defaults to `[]` (`_id` + `_score` only). Pass `["*"]` for all stored fields or a list of names to project. Omitting it on some SDK builds yields `400` / `422` instead of the documented default; always pass it explicitly to avoid surprises.
+- **`include_fields` is required on every `documents.search(...)` call.** When omitted, the key is left off the request and the server returns **all** stored fields. Pass `["*"]` for all stored fields or a list of names to project. Omitting it on some SDK builds yields `400` / `422` instead of the documented default; always pass it explicitly to avoid surprises.
 - **Match score is `_score`; doc id is `_id`.** Public-preview docs return the system match score on the `_score` field so a user metadata field literally named `score` can coexist. Always prefer `_score` on read; some older SDK builds may still surface plain `score`, so for defensive code use `getattr(m, "_score", getattr(m, "score", None))`.
 - **Reserved field names: leading `_` and `$`, max 64 bytes.** `_` is for system fields (`_id`, `_score`); `$` is for filter operators. Schema validation rejects names that violate either rule. Length cap is bytes, not characters — be careful with non-ASCII names.
 - **Vector-field cardinality: at most one `dense_vector` and at most one `sparse_vector` per index** in `2026-01.alpha`. Multiple text fields are fine.

--- a/skills/pinecone-full-text-search/references/onboarding-walkthrough.md
+++ b/skills/pinecone-full-text-search/references/onboarding-walkthrough.md
@@ -85,7 +85,7 @@ If any field starts with `_` or `$`:
 >     # Filter only — exact-match category like "fiction"
 >     .add_string_field("category", filterable=True)
 >     # Numeric range filter (e.g. year > 2024)
->     .add_integer_field("year", filterable=True)
+>     .add_float_field("year", filterable=True)
 >     # Tag filter — list membership ($in)
 >     .add_string_list_field("tags", filterable=True)
 >     .build()
@@ -93,7 +93,7 @@ If any field starts with `_` or `$`:
 >
 > A few notes:
 > - **No dense_vector field** — you said you don't have embeddings yet. We can add one later, but it requires creating a *new* index because schemas are immutable. Want to add a placeholder now and keep the door open?
-> - **`year` uses `add_integer_field`** but Pinecone stores it as `float` on the wire. The naming is confusing but normal — there's no separate integer type.
+> - **`year` uses `add_float_field`** — `float` is the only numeric wire type; there is no integer helper.
 > - **`tags`** will become `["a","b","c"]` after the comma-split we discussed.
 >
 > Schemas are immutable in `2026-01.alpha` — once we create this, changing it means re-creating the index and re-ingesting all the data.

--- a/skills/pinecone-full-text-search/references/schema-design.md
+++ b/skills/pinecone-full-text-search/references/schema-design.md
@@ -12,7 +12,7 @@ schema = (
     .add_string_field("title", full_text_search={"language": "en"})
     .add_string_field("body",  full_text_search={"language": "en", "stemming": True})
     .add_string_field("category", filterable=True)
-    .add_integer_field("year", filterable=True)              # emits `"type": "float"` on the wire
+    .add_float_field("year", filterable=True)                # `float` is the only numeric wire type
     .add_dense_vector_field("embedding",       dimension=1024, metric="cosine")
     .add_sparse_vector_field("sparse_embedding", metric="dotproduct")
     .build()            # terminal: returns the schema object you pass to indexes.create
@@ -81,18 +81,18 @@ Stored verbatim, not tokenized, not text-scored. Enables exact-match filtering: 
 ## Numeric, boolean, and array metadata
 
 ```python
-.add_integer_field("year", filterable=True)                              # wire type: "float"
-.add_custom_field("featured", {"type": "boolean", "filterable": True})  # no add_boolean_field helper in v9
+.add_float_field("year", filterable=True)      # `float` is the only numeric wire type
+.add_boolean_field("featured", filterable=True)
 .add_string_list_field("tags", filterable=True)
 ```
 
-- **`float`** is the only numeric wire type — there is no separate integer type. The SchemaBuilder helper is misleadingly named `add_integer_field` but emits `{"type": "float", "filterable": ...}`. Supports `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`.
-- **`boolean`** has no dedicated builder helper in pinecone v9 — declare via `add_custom_field("name", {"type": "boolean", "filterable": True})`. Supports `$eq` and `$exists`.
+- **`float`** is the only numeric wire type — there is no separate integer type, and **there is no `add_integer_field` helper**. Use `add_float_field`, which emits `{"type": "float", "filterable": ...}`. Note `describe()` may still report the field class as `PreviewIntegerField`. Supports `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`.
+- **`boolean`** uses `add_boolean_field("name", filterable=True)`. Supports `$eq` and `$exists`.
 - **`string_list`** supports `$in` / `$nin` membership semantics — handy for tag-style metadata.
 
 All filter operators compose under `$and`, `$or`, `$not`. Multiple keys at the top level of `filter` are combined with implicit AND.
 
-> **SchemaBuilder helper-name pitfall** (pinecone v9): `add_integer_field()` produces `{"type": "float"}`, not a separate integer type. The class name in `describe()` responses is also `PreviewIntegerField`, but the wire/server type is `"float"`. Use `add_integer_field` for any numeric metadata; use `add_custom_field` with an explicit `{"type": "boolean", ...}` dict for booleans.
+> **SchemaBuilder numeric-type pitfall**: there is no `add_integer_field()` helper — calling it raises `AttributeError`. Use `add_float_field()` for any numeric metadata; `float` is the only numeric wire type. `describe()` responses may still name the class `PreviewIntegerField`, but the wire/server type is `"float"`.
 
 > **Forward-looking note.** In the public preview, metadata fields you send at upsert time are auto-indexed for filtering even if not declared in the schema. In a future release, only schema-declared fields with `filterable: true` will be indexed. Declare your metadata fields in the schema today to be future-proof.
 


### PR DESCRIPTION
The FTS skill told agents to call `SchemaBuilder.add_integer_field()`. That method
does not exist in `pinecone` 9.x — calling it raises `AttributeError`, so any agent
following the documented schema-design path failed before creating an index.

Eight sites across `SKILL.md`, `references/schema-design.md`, and
`references/onboarding-walkthrough.md`.

**Corrections:**

- `add_integer_field` → `add_float_field`. `float` is the only numeric wire type;
  there is no integer helper. `describe()` may still report the field class as
  `PreviewIntegerField`, which is what the old text was reasoning from.
- `add_boolean_field(...)` exists. The docs claimed it didn't and recommended
  `add_custom_field("name", {"type": "boolean", ...})` as a workaround.
- Corrected the `include_fields` note. Omitting it does not default to
  `_id` + `_score`; the key is left off the request and the server returns all
  stored fields.

Verified against the installed SDK surface.
