### PR TITLE
feat: render skills per target from a manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ docs/
 .env
 .env.*
 !.env.example
+
+# build output — rendered per-target trees
+dist/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/targets/README.md
+++ b/targets/README.md
@@ -1,0 +1,87 @@
+# Target manifests
+
+One YAML per publish target. `tools/build.py` reads `skills/` plus a manifest and
+renders `dist/<target>/`. The build is a pure function: same inputs, same bytes.
+
+This replaces the old arrangement, where each target repo ran its own agent
+(`contextualize-skills.yml`) to rewrite skills on arrival. Three targets meant
+three agents and three different answers to the same question.
+
+## Fields
+
+| Field | Meaning |
+|---|---|
+| `repo` | `owner/name` of the publish target. Used by the sync workflow. |
+| `skills_path` | Directory inside the target repo that receives the skills tree. |
+| `dir_name` | Template for the on-disk directory name. `{slug}` is the base name minus the `pinecone-` prefix. |
+| `skill_name` | Template for the `name:` frontmatter value. |
+| `cross_reference` | Template for how prose refers to *another* skill. See the rule below. |
+| `source_tag` | Replaces `pinecone_skills` in the `source_tag=` argument inside `.py` files. |
+| `include` | Slugs to render. Explicit, so adding a skill to base does not silently publish it everywhere. |
+| `frontmatter` | Per-slug keys this target adds. Emitted after `argument-hint`. |
+
+## Frontmatter contract
+
+Base uses exactly four keys, and the build must emit them in this order:
+
+```
+name:            # rewritten per skill_name
+description:     # passed through unchanged
+argument-hint:   # passed through unchanged; only cli and query have one
+allowed-tools:   # added from the manifest; base has none
+```
+
+`description` is byte-identical across base and both live targets for 8 of 9
+skills. The exception is `query`, where the cursor copy has diverged — see
+"Known deltas".
+
+## The cross-reference rule
+
+**Do not blanket-substitute `pinecone-` → `pinecone:`.** That string also appears
+in prose, package names, URLs, and index names, and a global replace corrupts
+content silently.
+
+A cross-reference is only rewritten when the matched text is one of the nine
+`include` slugs prefixed by `pinecone-`, and the match is bounded by a non-word
+character on both sides. Concretely:
+
+| Text | Rewrite? | Why |
+|---|---|---|
+| `` `pinecone-assistant` `` | yes | `assistant` is a slug |
+| `the pinecone-cli skill` | yes | `cli` is a slug |
+| `pinecone-plugin-assistant` | **no** | `plugin-assistant` is not a slug |
+| `https://…/pinecone-io/skills` | **no** | `io` is not a slug |
+| `index name pinecone-demo` | **no** | `demo` is not a slug |
+
+The slug list is the guard. Anything not in `include` is left alone. The build
+should fail loudly if a rewrite count changes unexpectedly between runs rather
+than silently corrupting a file.
+
+## Verification the build owes us
+
+1. **Cursor is byte-identical to base except `source_tag`.** Cursor's manifest is
+   an identity transform on names and adds no frontmatter, so this is a cheap,
+   exact regression test. It replaces paid evals for that target.
+2. **Idempotence.** Building twice produces identical bytes.
+3. **Round-trip on names.** Every rendered `name:` matches the target's live
+   value for all nine skills.
+
+## Known deltas
+
+Recorded here so the build is not blamed for pre-existing drift. Resolving these
+is reconciliation work, not build work.
+
+- **claude is missing three files.** `assistant/references/{context,list,sync}.md`
+  exist in base and have never reached the plugin — the old sync diffed
+  `HEAD~1..HEAD` under `fetch-depth: 2` and dropped them. A full build fixes this
+  by construction.
+- **cursor's `query` skill is ahead of base.** 22 diff lines: it uses
+  `pinecone-cli` where base says "CLI skill", `/pinecone-query` where base says
+  `/query`, and — importantly — its `PINECONE_API_KEY` guidance explains Cursor's
+  `envFile` field, which base does not know about. That last one is a genuine
+  improvement and should be back-ported to base before any full sync overwrites
+  it. Same shape as the `create.py` case.
+- **cursor carries `.gitkeep` files** in eight skills. Base has none, so
+  `rsync --delete` will remove them. They are vestigial — every directory holding
+  one also holds real files — but it is a deletion, so it should be a deliberate
+  call rather than a surprise in the first sync PR.

--- a/targets/README.md
+++ b/targets/README.md
@@ -57,6 +57,37 @@ The slug list is the guard. Anything not in `include` is left alone. The build
 should fail loudly if a rewrite count changes unexpectedly between runs rather
 than silently corrupting a file.
 
+## Paths are not cross-references
+
+A slug followed by `/` is a directory in a filesystem path, so it follows
+`dir_name`, not `cross_reference`. The two rules are mutually exclusive: the
+cross-reference pattern rejects an adjacent `/` on either side.
+
+| Text | claude-code | cursor |
+|---|---|---|
+| `uv run ../pinecone-assistant/scripts/create.py` | `../assistant/scripts/…` | unchanged |
+| `` `pinecone-assistant` `` (prose) | `pinecone:assistant` | unchanged |
+
+This distinction is not theoretical. `pinecone-quickstart/SKILL.md` carries three
+such paths, and running them through `cross_reference` emitted
+`../pinecone:assistant/scripts/create.py` — a path that cannot exist on any
+filesystem. It was caught by `tools/reconcile.py`, not by unit tests.
+
+## Reconciling against the live repos
+
+```bash
+uv run tools/build.py --all
+uv run tools/reconcile.py --target cursor --clone ../plugin-cursor --diff
+```
+
+`reconcile.py` buckets the difference three ways — `MISSING` (sync adds),
+`EXTRA` (`rsync --delete` removes), `DIFFERS` (sync overwrites) — and exits
+nonzero while any remain. Before the first sync it is a migration report; after,
+a standing assertion that published content still matches what base renders.
+
+`EXTRA` and `DIFFERS` both need reading rather than trusting. A target can be
+legitimately *ahead* of base: `create.py` in the Claude plugin was, for months.
+
 ## Verification the build owes us
 
 1. **Cursor is byte-identical to base except `source_tag`.** Cursor's manifest is

--- a/targets/claude-code.yaml
+++ b/targets/claude-code.yaml
@@ -1,0 +1,60 @@
+# Build manifest — Claude Code plugin
+#
+# Consumed by tools/build.py, which renders skills/ -> dist/claude-code/.
+# Every value here was derived from the observed state of the live target repo
+# on 2026-08-05, not from a design document. See targets/README.md for the
+# field reference.
+
+repo: pinecone-io/pinecone-claude-code-plugin
+skills_path: skills
+
+# Directory rename: base `skills/pinecone-assistant/` -> `skills/assistant/`.
+# The plugin namespaces skills via `name:`, so the prefix is redundant on disk.
+dir_name: "{slug}"
+
+# Frontmatter `name:`. Claude Code uses `<plugin>:<skill>` for slash invocation.
+skill_name: "pinecone:{slug}"
+
+# How this target writes a reference to another skill in prose. Base authors
+# these as `pinecone-<slug>`; see README.md for what counts as a reference —
+# a blanket substitution corrupts URLs and index names.
+cross_reference: "pinecone:{slug}"
+
+# Replaces `pinecone_skills:` in the source_tag argument inside .py files.
+source_tag: claude_code_plugin
+
+include:
+  - assistant
+  - cli
+  - docs
+  - full-text-search
+  - help
+  - mcp
+  - n8n
+  - query
+  - quickstart
+
+# Per-skill frontmatter added by this target only. Values are verbatim from the
+# live plugin. Emitted last in the frontmatter block, after argument-hint.
+#
+# Base carries no allowed-tools: the key is Claude-Code-specific and was removed
+# from pinecone-n8n as part of the neutrality pass.
+frontmatter:
+  assistant:
+    allowed-tools: "Bash, Read"
+  cli:
+    allowed-tools: "Bash, Read"
+  docs:
+    allowed-tools: "Read, WebFetch"
+  full-text-search:
+    allowed-tools: "Bash, Read"
+  help:
+    allowed-tools: "Skill, Bash, Read"
+  mcp:
+    allowed-tools: "Read"
+  n8n:
+    allowed-tools: "Write, Read"
+  query:
+    allowed-tools: "Bash, Read"
+  quickstart:
+    allowed-tools: "Skill(pinecone:assistant *), Bash, Read"

--- a/targets/cursor.yaml
+++ b/targets/cursor.yaml
@@ -1,0 +1,39 @@
+# Build manifest — Cursor plugin
+#
+# Consumed by tools/build.py, which renders skills/ -> dist/cursor/.
+# Derived from the observed state of the live target repo on 2026-08-05.
+#
+# This target is an identity transform on directory names and on `name:`, and
+# adds no frontmatter. The only difference from base is source_tag. That makes
+# it the cheapest target to prove the pipeline against: build output should be
+# byte-identical to base except for the source_tag line, and the build asserts
+# exactly that (see targets/README.md).
+
+repo: pinecone-io/pinecone-cursor-plugin
+skills_path: skills
+
+# Identical to base — Cursor has no plugin namespace, so the prefix stays on disk.
+dir_name: "pinecone-{slug}"
+
+# Identical to base.
+skill_name: "pinecone-{slug}"
+
+# Identical to base, so cross-reference rewriting is a no-op here.
+cross_reference: "pinecone-{slug}"
+
+source_tag: cursor_plugin
+
+include:
+  - assistant
+  - cli
+  - docs
+  - full-text-search
+  - help
+  - mcp
+  - n8n
+  - query
+  - quickstart
+
+# Cursor adds no per-skill frontmatter. Verified: 0 of 9 live skills carry
+# allowed-tools.
+frontmatter: {}

--- a/tools/build.py
+++ b/tools/build.py
@@ -72,6 +72,11 @@ def available_targets() -> list[str]:
 # transforms — each is a pure str -> str
 # --------------------------------------------------------------------------- #
 
+def slug_alternation(slugs: list[str]) -> str:
+    """Longest slug first, so `full-text-search` wins over any shorter alternative."""
+    return "|".join(re.escape(s) for s in sorted(slugs, key=len, reverse=True))
+
+
 def cross_reference_pattern(slugs: list[str]) -> re.Pattern[str]:
     """Match `pinecone-<slug>` only for known slugs, and only when it stands alone.
 
@@ -85,22 +90,44 @@ def cross_reference_pattern(slugs: list[str]) -> re.Pattern[str]:
     either side fixes that, and also protects trailing forms like
     `pinecone-cli-tool`.
 
-    Longest slug first so `full-text-search` wins over any shorter alternative.
+    An adjacent `/` is rejected for a different reason: that is a path segment, not
+    prose, and paths follow `dir_name` rather than `cross_reference`. See
+    `rewrite_skill_paths`.
     """
-    alts = "|".join(re.escape(s) for s in sorted(slugs, key=len, reverse=True))
-    return re.compile(rf"(?<![\w-]){re.escape(BASE_PREFIX)}(?:{alts})(?![\w-])")
+    return re.compile(rf"(?<![\w/-]){re.escape(BASE_PREFIX)}(?:{slug_alternation(slugs)})(?![\w/-])")
+
+
+def skill_path_pattern(slugs: list[str]) -> re.Pattern[str]:
+    """Match `pinecone-<slug>/` — a skill directory used as a path segment."""
+    return re.compile(rf"(?<![\w-]){re.escape(BASE_PREFIX)}(?:{slug_alternation(slugs)})(?=/)")
+
+
+def rewrite_skill_paths(text: str, manifest: dict[str, Any]) -> str:
+    """Rewrite skill directories that appear inside filesystem paths.
+
+    `pinecone-quickstart/SKILL.md` tells the user to run
+    `uv run ../pinecone-assistant/scripts/create.py`. That is a real path to a
+    sibling directory, so it has to track `dir_name`: the Claude plugin renames the
+    directory to `assistant/`, and a build that emitted `../pinecone-assistant/`
+    there would hand the user a path that does not exist. Feeding it through
+    `cross_reference` instead is worse — it produced `../pinecone:assistant/`.
+    """
+    def repl(match: re.Match[str]) -> str:
+        return manifest["dir_name"].format(slug=match.group(0)[len(BASE_PREFIX):])
+
+    return skill_path_pattern(manifest["include"]).sub(repl, text)
 
 
 def rewrite_cross_references(text: str, manifest: dict[str, Any]) -> str:
-    slugs = manifest["include"]
+    """Rewrite prose references to other skills. Paths are handled first and are
+    excluded by the pattern's lookarounds, so the two rules cannot both fire."""
+    text = rewrite_skill_paths(text, manifest)
     template = manifest["cross_reference"]
-    pattern = cross_reference_pattern(slugs)
 
     def repl(match: re.Match[str]) -> str:
-        slug = match.group(0)[len(BASE_PREFIX):]
-        return template.format(slug=slug)
+        return template.format(slug=match.group(0)[len(BASE_PREFIX):])
 
-    return pattern.sub(repl, text)
+    return cross_reference_pattern(manifest["include"]).sub(repl, text)
 
 
 def rewrite_source_tag(text: str, manifest: dict[str, Any]) -> str:

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "pyyaml>=6.0",
+#   "typer>=0.15.0",
+# ]
+# ///
+"""Render skills/ into dist/<target>/ using a target manifest.
+
+Replaces the previous arrangement, where each target repo ran its own agent to
+rewrite skills on arrival — three targets, three agents, three answers to the
+same question. This is a pure function: same inputs, same bytes, every run.
+
+    uv run tools/build.py --all
+    uv run tools/build.py --target claude-code
+    uv run tools/build.py --all --check    # verify only, write nothing
+
+See targets/README.md for the manifest schema and the transform rules.
+"""
+
+from __future__ import annotations
+
+import filecmp
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+import typer
+import yaml
+
+app = typer.Typer(add_completion=False, pretty_exceptions_enable=False)
+
+REPO = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO / "skills"
+TARGETS_DIR = REPO / "targets"
+DIST_DIR = REPO / "dist"
+
+BASE_PREFIX = "pinecone-"
+NEUTRAL_SOURCE_TAG = "pinecone_skills"
+
+# Frontmatter keys, in the order the build must emit them. `allowed-tools` comes
+# from the manifest and is appended last; the rest pass through from base.
+FRONTMATTER_ORDER = ["name", "description", "argument-hint", "allowed-tools"]
+
+
+# --------------------------------------------------------------------------- #
+# manifest
+# --------------------------------------------------------------------------- #
+
+def load_manifest(target: str) -> dict[str, Any]:
+    path = TARGETS_DIR / f"{target}.yaml"
+    if not path.exists():
+        raise typer.BadParameter(f"no manifest at {path.relative_to(REPO)}")
+    m = yaml.safe_load(path.read_text())
+    for key in ("repo", "skills_path", "dir_name", "skill_name", "cross_reference", "source_tag", "include"):
+        if key not in m:
+            raise ValueError(f"{target}.yaml is missing required key: {key}")
+    m.setdefault("frontmatter", {}) or m.__setitem__("frontmatter", m.get("frontmatter") or {})
+    unknown = set(m["frontmatter"]) - set(m["include"])
+    if unknown:
+        raise ValueError(f"{target}.yaml has frontmatter for non-included slugs: {sorted(unknown)}")
+    return m
+
+
+def available_targets() -> list[str]:
+    return sorted(p.stem for p in TARGETS_DIR.glob("*.yaml"))
+
+
+# --------------------------------------------------------------------------- #
+# transforms — each is a pure str -> str
+# --------------------------------------------------------------------------- #
+
+def cross_reference_pattern(slugs: list[str]) -> re.Pattern[str]:
+    """Match `pinecone-<slug>` only for known slugs, and only when it stands alone.
+
+    The slug list is the first guard: a blanket `pinecone-` substitution would eat
+    `pinecone-io` URLs and index names like `pinecone-fts-index`.
+
+    The lookarounds are the second, and they are not optional. `\\b` is too weak
+    here because a hyphen is a word boundary, so `\\bpinecone-assistant\\b` matches
+    *inside* `@pinecone-database/n8n-nodes-pinecone-assistant` and rewrites an npm
+    package name to `n8n-nodes-pinecone:assistant`. Rejecting an adjacent `-` on
+    either side fixes that, and also protects trailing forms like
+    `pinecone-cli-tool`.
+
+    Longest slug first so `full-text-search` wins over any shorter alternative.
+    """
+    alts = "|".join(re.escape(s) for s in sorted(slugs, key=len, reverse=True))
+    return re.compile(rf"(?<![\w-]){re.escape(BASE_PREFIX)}(?:{alts})(?![\w-])")
+
+
+def rewrite_cross_references(text: str, manifest: dict[str, Any]) -> str:
+    slugs = manifest["include"]
+    template = manifest["cross_reference"]
+    pattern = cross_reference_pattern(slugs)
+
+    def repl(match: re.Match[str]) -> str:
+        slug = match.group(0)[len(BASE_PREFIX):]
+        return template.format(slug=slug)
+
+    return pattern.sub(repl, text)
+
+
+def rewrite_source_tag(text: str, manifest: dict[str, Any]) -> str:
+    """Retarget `pinecone_skills:<x>` to `<target_tag>:<x>` inside .py files."""
+    return re.sub(
+        rf"\b{re.escape(NEUTRAL_SOURCE_TAG)}:",
+        f"{manifest['source_tag']}:",
+        text,
+    )
+
+
+def split_frontmatter(text: str, path: Path) -> tuple[dict[str, str], str]:
+    """Return (frontmatter dict, body). Preserves value strings verbatim."""
+    if not text.startswith("---\n"):
+        raise ValueError(f"{path}: SKILL.md must open with a --- frontmatter block")
+    end = text.find("\n---\n", 3)
+    if end == -1:
+        raise ValueError(f"{path}: unterminated frontmatter block")
+    block, body = text[4:end + 1], text[end + 5:]
+
+    fm: dict[str, str] = {}
+    for line in block.splitlines():
+        if not line.strip():
+            continue
+        if ": " not in line and not line.endswith(":"):
+            raise ValueError(f"{path}: cannot parse frontmatter line: {line!r}")
+        key, _, value = line.partition(":")
+        fm[key.strip()] = value.strip()
+    return fm, body
+
+
+def render_frontmatter(fm: dict[str, str]) -> str:
+    """Emit keys in FRONTMATTER_ORDER; anything unrecognised is an error rather
+    than silently dropped."""
+    unknown = [k for k in fm if k not in FRONTMATTER_ORDER]
+    if unknown:
+        raise ValueError(f"unhandled frontmatter keys: {unknown} (add them to FRONTMATTER_ORDER)")
+    lines = [f"{k}: {fm[k]}" for k in FRONTMATTER_ORDER if k in fm]
+    return "---\n" + "\n".join(lines) + "\n---\n"
+
+
+def render_skill_md(text: str, slug: str, manifest: dict[str, Any], path: Path) -> str:
+    fm, body = split_frontmatter(text, path)
+
+    expected = f"{BASE_PREFIX}{slug}"
+    if fm.get("name") != expected:
+        raise ValueError(f"{path}: name is {fm.get('name')!r}, expected {expected!r}")
+    fm["name"] = manifest["skill_name"].format(slug=slug)
+
+    extra = (manifest["frontmatter"].get(slug) or {})
+    for key, value in extra.items():
+        fm[key] = value
+
+    # Cross-references appear in the description as well as the body.
+    if "description" in fm:
+        fm["description"] = rewrite_cross_references(fm["description"], manifest)
+    return render_frontmatter(fm) + rewrite_cross_references(body, manifest)
+
+
+def render_file(rel: Path, text: str, slug: str, manifest: dict[str, Any], path: Path) -> str:
+    if rel.name == "SKILL.md":
+        return render_skill_md(text, slug, manifest, path)
+    if rel.suffix == ".py":
+        return rewrite_source_tag(text, manifest)
+    if rel.suffix == ".md":
+        return rewrite_cross_references(text, manifest)
+    return text
+
+
+# --------------------------------------------------------------------------- #
+# build
+# --------------------------------------------------------------------------- #
+
+def build_target(target: str, out_root: Path | None = None) -> tuple[Path, int]:
+    """Render one target. Returns (output dir, files written)."""
+    manifest = load_manifest(target)
+    out = (out_root or DIST_DIR) / target / manifest["skills_path"]
+    if out.parent.exists():
+        shutil.rmtree(out.parent)
+    out.mkdir(parents=True)
+
+    written = 0
+    for slug in manifest["include"]:
+        src = SKILLS_DIR / f"{BASE_PREFIX}{slug}"
+        if not src.is_dir():
+            raise ValueError(f"{target}: include lists {slug!r} but {src.relative_to(REPO)} does not exist")
+        dest_dir = out / manifest["dir_name"].format(slug=slug)
+
+        for path in sorted(src.rglob("*")):
+            if path.is_dir() or "__pycache__" in path.parts:
+                continue
+            rel = path.relative_to(src)
+            dest = dest_dir / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                text = path.read_text()
+            except UnicodeDecodeError:          # binary asset: copy through
+                shutil.copy2(path, dest)
+                written += 1
+                continue
+            dest.write_text(render_file(rel, text, slug, manifest, path))
+            written += 1
+    return out.parent, written
+
+
+# --------------------------------------------------------------------------- #
+# checks
+# --------------------------------------------------------------------------- #
+
+def check_identity_target(target: str, out_root: Path | None = None) -> list[str]:
+    """For a target whose dir_name and skill_name equal base, rendered output must
+    be byte-identical to base except for source_tag lines.
+
+    This is the cheapest possible regression test for such a target — it replaces
+    a paid eval run with an exact comparison.
+    """
+    manifest = load_manifest(target)
+    if manifest["dir_name"] != f"{BASE_PREFIX}{{slug}}" or manifest["skill_name"] != f"{BASE_PREFIX}{{slug}}":
+        return []                                # not an identity target; nothing to assert
+    out = (out_root or DIST_DIR) / target / manifest["skills_path"]
+    problems: list[str] = []
+    for slug in manifest["include"]:
+        base = SKILLS_DIR / f"{BASE_PREFIX}{slug}"
+        rendered = out / f"{BASE_PREFIX}{slug}"
+        for path in sorted(base.rglob("*")):
+            if path.is_dir() or "__pycache__" in path.parts:
+                continue
+            rel = path.relative_to(base)
+            other = rendered / rel
+            if not other.exists():
+                problems.append(f"{target}: missing {rel} under {slug}")
+                continue
+            a = path.read_text().splitlines()
+            b = other.read_text().splitlines()
+            if len(a) != len(b):
+                problems.append(f"{target}: line count differs for {slug}/{rel}")
+                continue
+            for i, (la, lb) in enumerate(zip(a, b), 1):
+                if la == lb:
+                    continue
+                if NEUTRAL_SOURCE_TAG in la and manifest["source_tag"] in lb:
+                    continue                     # the one permitted difference
+                problems.append(f"{target}: unexpected change at {slug}/{rel}:{i}\n    - {la}\n    + {lb}")
+    return problems
+
+
+def check_no_neutral_tags(target: str, out_root: Path | None = None) -> list[str]:
+    """No rendered output may still carry the neutral source tag."""
+    manifest = load_manifest(target)
+    out = (out_root or DIST_DIR) / target / manifest["skills_path"]
+    return [
+        f"{target}: {p.relative_to(out)} still contains {NEUTRAL_SOURCE_TAG}:"
+        for p in out.rglob("*.py")
+        if f"{NEUTRAL_SOURCE_TAG}:" in p.read_text()
+    ]
+
+
+def check_idempotent(target: str, tmp_root: Path) -> list[str]:
+    """Building twice must produce identical bytes."""
+    a, _ = build_target(target, tmp_root / "a")
+    b, _ = build_target(target, tmp_root / "b")
+    diff = filecmp.dircmp(a, b)
+
+    def walk(d: filecmp.dircmp) -> list[str]:
+        out = [f"{target}: not idempotent — {n}" for n in d.diff_files + d.left_only + d.right_only]
+        for sub in d.subdirs.values():
+            out += walk(sub)
+        return out
+
+    return walk(diff)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+@app.command()
+def main(
+    target: str = typer.Option("", "--target", "-t", help="Target manifest name, e.g. claude-code."),
+    all_targets: bool = typer.Option(False, "--all", help="Build every manifest in targets/."),
+    check: bool = typer.Option(False, "--check", help="Run the checks; write nothing permanent."),
+    out: str = typer.Option("", "--out", help="Output root. Defaults to dist/."),
+):
+    """Render skills/ into dist/<target>/ from a target manifest."""
+    if not target and not all_targets:
+        raise typer.BadParameter("pass --target NAME or --all")
+    targets = available_targets() if all_targets else [target]
+    out_root = Path(out).resolve() if out else None
+
+    problems: list[str] = []
+    for t in targets:
+        path, n = build_target(t, out_root)
+        typer.echo(f"built {t}: {n} files -> {path.relative_to(REPO) if not out_root else path}")
+        problems += check_no_neutral_tags(t, out_root)
+        problems += check_identity_target(t, out_root)
+        if check:
+            import tempfile
+            with tempfile.TemporaryDirectory() as tmp:
+                problems += check_idempotent(t, Path(tmp))
+
+    if problems:
+        typer.echo("\nFAILED:")
+        for p in problems:
+            typer.echo(f"  {p}")
+        raise typer.Exit(1)
+    typer.echo("all checks passed")
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/reconcile.py
+++ b/tools/reconcile.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "pyyaml>=6.0",
+#   "typer>=0.15.0",
+# ]
+# ///
+"""Diff a rendered target tree against the live plugin repo.
+
+    uv run tools/reconcile.py --target cursor --clone ../plugin-cursor
+    uv run tools/reconcile.py --target claude-code --clone ../plugin-claude --diff
+
+Once the sync pipeline is running this is a steady-state assertion: live and
+rendered agree, exit 0. Before the first sync it is a migration report, and the
+three buckets are not interchangeable —
+
+    MISSING   in rendered, not live       sync adds it
+    EXTRA     in live, not rendered       `rsync --delete` REMOVES it
+    DIFFERS   in both, contents disagree  sync overwrites live
+
+EXTRA is the one to read carefully. A file only the target has is either
+vestigial or a downstream edit that was never back-ported, and `--delete` cannot
+tell the difference. Same for DIFFERS: base is not automatically right.
+`create.py` in the Claude plugin was ahead of base for months.
+
+Reads live content from a git ref rather than the working tree, so a dirty clone
+or a stale checkout cannot quietly change the answer.
+"""
+
+from __future__ import annotations
+
+import difflib
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import typer
+import yaml
+
+app = typer.Typer(add_completion=False, pretty_exceptions_enable=False)
+
+REPO = Path(__file__).resolve().parent.parent
+TARGETS_DIR = REPO / "targets"
+DIST_DIR = REPO / "dist"
+
+BINARY = "\0<binary>"
+
+
+def load_manifest(target: str) -> dict[str, Any]:
+    path = TARGETS_DIR / f"{target}.yaml"
+    if not path.exists():
+        raise typer.BadParameter(f"no manifest at {path.relative_to(REPO)}")
+    return yaml.safe_load(path.read_text())
+
+
+def git(clone: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(clone), *args],
+        capture_output=True, text=True, check=False, errors="replace",
+    )
+    if result.returncode != 0:
+        raise typer.BadParameter(f"git {' '.join(args)} failed in {clone}:\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def live_files(clone: Path, ref: str, skills_path: str) -> dict[str, str]:
+    """Map path-relative-to-skills_path -> contents, read from `ref`."""
+    listing = git(clone, "ls-tree", "-r", "--name-only", "-z", ref, "--", skills_path)
+    files: dict[str, str] = {}
+    for name in listing.split("\0"):
+        if not name:
+            continue
+        rel = name[len(skills_path):].lstrip("/")
+        blob = git(clone, "show", f"{ref}:{name}")
+        files[rel] = BINARY if "\0" in blob else blob
+    return files
+
+
+def rendered_files(target: str, skills_path: str) -> dict[str, str]:
+    root = DIST_DIR / target / skills_path
+    if not root.is_dir():
+        raise typer.BadParameter(f"{root.relative_to(REPO)} does not exist — run tools/build.py first")
+    files: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_dir() or "__pycache__" in path.parts:
+            continue
+        rel = str(path.relative_to(root))
+        try:
+            files[rel] = path.read_text()
+        except UnicodeDecodeError:
+            files[rel] = BINARY
+    return files
+
+
+@app.command()
+def main(
+    target: str = typer.Option(..., "--target", "-t", help="Target manifest name, e.g. cursor."),
+    clone: Path = typer.Option(..., "--clone", "-c", help="Path to a local clone of the target repo."),
+    ref: str = typer.Option("origin/main", "--ref", help="Git ref in the clone to compare against."),
+    diff: bool = typer.Option(False, "--diff", help="Print a unified diff for every DIFFERS file."),
+):
+    """Compare dist/<target>/ against the live target repo."""
+    manifest = load_manifest(target)
+    skills_path = manifest["skills_path"]
+
+    live = live_files(clone.resolve(), ref, skills_path)
+    built = rendered_files(target, skills_path)
+
+    missing = sorted(set(built) - set(live))
+    extra = sorted(set(live) - set(built))
+    differs = sorted(k for k in set(built) & set(live) if built[k] != live[k])
+
+    typer.echo(f"{target}  vs  {manifest['repo']} @ {ref}")
+    typer.echo(f"  rendered {len(built)} files, live {len(live)} files\n")
+
+    for label, items, note in [
+        ("MISSING", missing, "sync will add"),
+        ("EXTRA", extra, "rsync --delete will REMOVE"),
+        ("DIFFERS", differs, "sync will overwrite"),
+    ]:
+        typer.echo(f"{label} ({len(items)}) — {note}")
+        for item in items:
+            typer.echo(f"    {item}")
+        typer.echo("")
+
+    if diff:
+        for key in differs:
+            typer.echo(f"--- diff {key} " + "-" * max(0, 60 - len(key)))
+            if BINARY in (live[key], built[key]):
+                typer.echo("    (binary)")
+            else:
+                for line in difflib.unified_diff(
+                    live[key].splitlines(), built[key].splitlines(),
+                    fromfile=f"live/{key}", tofile=f"built/{key}", lineterm="",
+                ):
+                    typer.echo(line)
+            typer.echo("")
+
+    total = len(missing) + len(extra) + len(differs)
+    typer.echo(f"{total} discrepancies" if total else "in sync")
+    raise typer.Exit(1 if total else 0)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "pytest>=8.0",
+#   "pyyaml>=6.0",
+#   "typer>=0.15.0",
+# ]
+# ///
+"""Tests for tools/build.py.
+
+Run: uv run tools/test_build.py
+
+The cross-reference tests are the important ones. That rewrite is the only part of
+the transform that can silently corrupt content, and an early version of it did:
+`\\bpinecone-assistant\\b` matched inside `@pinecone-database/n8n-nodes-pinecone-assistant`
+and rewrote a real npm package name. Every no-op case below is a string that
+actually appears in this repo's content.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import build  # noqa: E402
+
+SLUGS = ["assistant", "cli", "docs", "full-text-search", "help", "mcp", "n8n", "query", "quickstart"]
+CLAUDE = {"include": SLUGS, "cross_reference": "pinecone:{slug}", "source_tag": "claude_code_plugin"}
+CURSOR = {"include": SLUGS, "cross_reference": "pinecone-{slug}", "source_tag": "cursor_plugin"}
+
+
+def xref(text, manifest=CLAUDE):
+    return build.rewrite_cross_references(text, manifest)
+
+
+class TestCrossReferencesRewritten:
+    @pytest.mark.parametrize("before,after", [
+        ("see pinecone-assistant", "see pinecone:assistant"),
+        ("`pinecone-cli`", "`pinecone:cli`"),
+        ("use the pinecone-full-text-search skill", "use the pinecone:full-text-search skill"),
+        ("pinecone-quickstart.", "pinecone:quickstart."),
+        ("(pinecone-n8n)", "(pinecone:n8n)"),
+        ("pinecone-docs and pinecone-help", "pinecone:docs and pinecone:help"),
+        ("pinecone-mcp\n", "pinecone:mcp\n"),
+    ])
+    def test_rewritten(self, before, after):
+        assert xref(before) == after
+
+    def test_start_of_string(self):
+        assert xref("pinecone-query is the skill") == "pinecone:query is the skill"
+
+
+class TestCrossReferencesLeftAlone:
+    """Every one of these is a real string from this repo. A regression here
+    corrupts published content silently."""
+
+    @pytest.mark.parametrize("text", [
+        # the bug that shipped: hyphen before `pinecone` is a \b, so \b was not enough
+        "`@pinecone-database/n8n-nodes-pinecone-assistant`",
+        "@pinecone-database/n8n-nodes-pinecone-assistant.pineconeAssistant",
+        "@pinecone-database/n8n-nodes-pinecone-assistant.pineconeAssistantTool",
+        # not slugs
+        "https://github.com/pinecone-io/skills",
+        "pinecone-plugin-assistant",
+        "claude/skills/pinecone-fts-index/scripts/ingest.py",
+        "pinecone-database",
+        # slug followed by a hyphen is a different identifier
+        "pinecone-cli-tool",
+        "pinecone-assistant-v2",
+        # substring of a longer word
+        "pinecone-clients",
+        # unrelated
+        "pinecone_skills:assistant",
+        "brew install pinecone-io/tap/pinecone",
+    ])
+    def test_untouched(self, text):
+        assert xref(text) == text
+
+
+class TestIdentityTarget:
+    def test_cursor_cross_reference_is_a_noop(self):
+        for s in ["pinecone-assistant", "the pinecone-cli skill", "`pinecone-n8n`"]:
+            assert xref(s, CURSOR) == s
+
+
+class TestSourceTag:
+    def test_rewrites_neutral_prefix(self):
+        line = 'pc = Pinecone(api_key=k, source_tag="pinecone_skills:assistant")'
+        assert build.rewrite_source_tag(line, CLAUDE) == \
+            'pc = Pinecone(api_key=k, source_tag="claude_code_plugin:assistant")'
+
+    def test_preserves_operation_suffix(self):
+        line = 'source_tag="pinecone_skills:quickstart_upsert"'
+        assert build.rewrite_source_tag(line, CURSOR) == 'source_tag="cursor_plugin:quickstart_upsert"'
+
+    def test_leaves_an_already_targeted_tag_alone(self):
+        line = 'source_tag="claude_code_plugin:assistant"'
+        assert build.rewrite_source_tag(line, CURSOR) == line
+
+
+class TestFrontmatter:
+    BASE = "---\nname: pinecone-quickstart\ndescription: Do a thing.\n---\nBody here.\n"
+
+    def test_name_rewritten_and_allowed_tools_appended_last(self):
+        m = dict(CLAUDE, skill_name="pinecone:{slug}",
+                 frontmatter={"quickstart": {"allowed-tools": "Skill, Bash, Read"}})
+        out = build.render_skill_md(self.BASE, "quickstart", m, Path("x"))
+        assert out.startswith(
+            "---\nname: pinecone:quickstart\ndescription: Do a thing.\nallowed-tools: Skill, Bash, Read\n---\n"
+        )
+
+    def test_argument_hint_precedes_allowed_tools(self):
+        src = "---\nname: pinecone-cli\ndescription: D\nargument-hint: install | auth\n---\nB\n"
+        m = dict(CLAUDE, skill_name="pinecone:{slug}",
+                 frontmatter={"cli": {"allowed-tools": "Bash, Read"}})
+        out = build.render_skill_md(src, "cli", m, Path("x"))
+        keys = [l.split(":")[0] for l in out.split("---\n")[1].strip().splitlines()]
+        assert keys == ["name", "description", "argument-hint", "allowed-tools"]
+
+    def test_no_allowed_tools_when_manifest_has_none(self):
+        m = dict(CURSOR, skill_name="pinecone-{slug}", frontmatter={})
+        out = build.render_skill_md(self.BASE, "quickstart", m, Path("x"))
+        assert "allowed-tools" not in out
+        assert "name: pinecone-quickstart" in out
+
+    def test_description_cross_references_rewritten(self):
+        src = "---\nname: pinecone-help\ndescription: See pinecone-cli for more.\n---\nB\n"
+        m = dict(CLAUDE, skill_name="pinecone:{slug}", frontmatter={})
+        out = build.render_skill_md(src, "help", m, Path("x"))
+        assert "description: See pinecone:cli for more." in out
+
+    def test_wrong_base_name_is_an_error(self):
+        src = "---\nname: pinecone-wrong\ndescription: D\n---\nB\n"
+        m = dict(CLAUDE, skill_name="pinecone:{slug}", frontmatter={})
+        with pytest.raises(ValueError, match="expected"):
+            build.render_skill_md(src, "quickstart", m, Path("x"))
+
+    def test_unknown_frontmatter_key_is_an_error(self):
+        """Better to fail than to silently drop a key a future skill adds."""
+        src = "---\nname: pinecone-help\ndescription: D\nmystery: x\n---\nB\n"
+        m = dict(CLAUDE, skill_name="pinecone:{slug}", frontmatter={})
+        with pytest.raises(ValueError, match="unhandled frontmatter"):
+            build.render_skill_md(src, "help", m, Path("x"))
+
+    def test_missing_frontmatter_is_an_error(self):
+        with pytest.raises(ValueError, match="must open with"):
+            build.render_skill_md("no frontmatter here\n", "help", CLAUDE, Path("x"))
+
+
+class TestFileDispatch:
+    def test_py_gets_source_tag_only_not_cross_refs(self):
+        text = '# see pinecone-assistant\nsource_tag="pinecone_skills:cli"\n'
+        out = build.render_file(Path("scripts/x.py"), text, "cli", CLAUDE, Path("x"))
+        assert "claude_code_plugin:cli" in out
+        assert "pinecone-assistant" in out, "python comments are not skill prose; leave them alone"
+
+    def test_reference_md_gets_cross_refs(self):
+        out = build.render_file(Path("references/a.md"), "see pinecone-cli\n", "docs", CLAUDE, Path("x"))
+        assert out == "see pinecone:cli\n"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -27,8 +27,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import build  # noqa: E402
 
 SLUGS = ["assistant", "cli", "docs", "full-text-search", "help", "mcp", "n8n", "query", "quickstart"]
-CLAUDE = {"include": SLUGS, "cross_reference": "pinecone:{slug}", "source_tag": "claude_code_plugin"}
-CURSOR = {"include": SLUGS, "cross_reference": "pinecone-{slug}", "source_tag": "cursor_plugin"}
+CLAUDE = {"include": SLUGS, "cross_reference": "pinecone:{slug}", "dir_name": "{slug}",
+          "source_tag": "claude_code_plugin"}
+CURSOR = {"include": SLUGS, "cross_reference": "pinecone-{slug}", "dir_name": "pinecone-{slug}",
+          "source_tag": "cursor_plugin"}
 
 
 def xref(text, manifest=CLAUDE):
@@ -77,6 +79,34 @@ class TestCrossReferencesLeftAlone:
     ])
     def test_untouched(self, text):
         assert xref(text) == text
+
+
+class TestSkillPaths:
+    """`pinecone-<slug>/` inside a path follows dir_name, not cross_reference.
+    Rendering `../pinecone:assistant/scripts/create.py` shipped a path that cannot
+    exist; rendering `../pinecone-assistant/` for Claude ships one that no longer
+    does, because the plugin renames the directory."""
+
+    @pytest.mark.parametrize("before,after", [
+        ("uv run ../pinecone-assistant/scripts/create.py",
+         "uv run ../assistant/scripts/create.py"),
+        ("see pinecone-full-text-search/references/querying.md",
+         "see full-text-search/references/querying.md"),
+        ("skills/pinecone-quickstart/SKILL.md", "skills/quickstart/SKILL.md"),
+    ])
+    def test_claude_path_follows_dir_name(self, before, after):
+        assert xref(before) == after
+
+    def test_cursor_path_is_a_noop(self):
+        s = "uv run ../pinecone-assistant/scripts/create.py"
+        assert xref(s, CURSOR) == s
+
+    def test_non_slug_path_segment_untouched(self):
+        s = "claude/skills/pinecone-fts-index/scripts/ingest.py"
+        assert xref(s) == s
+
+    def test_trailing_slash_alone_is_still_a_path(self):
+        assert xref("the pinecone-cli/ directory") == "the cli/ directory"
 
 
 class TestIdentityTarget:


### PR DESCRIPTION
Adds a deterministic build: `targets/<name>.yaml` + `skills/` → `dist/<name>/`.

Today each plugin repo runs an agent to adapt skills on arrival.
This replaces that with a pure function: same inputs, same bytes, every run.

## What's here

- **`targets/claude-code.yaml`, `targets/cursor.yaml`** — one manifest per target.
  Every value was derived from the observed state of the live repo, not from a
  design document. `targets/README.md` documents the schema.
- **`tools/build.py`** — the renderer, plus three self-checks.
- **`tools/reconcile.py`** — diffs rendered output against a live plugin repo.
- **`tools/test_build.py`** — 39 tests.

```bash
uv run tools/build.py --all --check
uv run tools/reconcile.py --target cursor --clone ../pinecone-cursor-plugin --diff
```

## The transform rules

Four per-target substitutions: directory name, frontmatter `name:`, `source_tag`,
and prose cross-references to other skills.

**Cross-references are the only rule that can silently corrupt content**, and
`targets/README.md` documents why at length. `pinecone-` is not a safe string to
substitute: it also appears in URLs (`pinecone-io/skills`), package names
(`@pinecone-database/n8n-nodes-pinecone-assistant`), and index names. Two guards —
the match must be one of the manifest's `include` slugs, and it must not be
adjacent to a word character, `-`, or `/`.
