### PR TITLE
fix: per-target values and wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,11 @@ This is the **base skills repo**. Skills here must work across any agent environ
 
 ## Generalization Rules
 
-**No IDE-specific tool calls.** Don't use `AskUserQuestion` or any tool that isn't universally available. Use plain prose: "ask the user which they prefer."
+**No IDE-specific tool calls in base.** Don't name `AskUserQuestion` or any other tool that isn't universally available. Write plain prose: "ask the user which they prefer."
+
+**Where a tool really is the right answer for one target, use a snippet instead of dropping the idea.** Base leaves a `<<marker>>`; each file in `targets/` supplies its own wording. That is how `AskUserQuestion` reaches the Claude Code plugin while Cursor gets prose — see `targets/README.md` → Snippets. Earlier the rule was a flat ban, which quietly cost the Claude plugin a working feature at 15 sites.
+
+Add a snippet only where the targets truly differ. If one wording is right everywhere, it belongs in base.
 
 **Never assume `PINECONE_API_KEY` is inherited.** Always check first. If not set:
 - Tell the user to `export PINECONE_API_KEY=...` (terminal envs)

--- a/skills/pinecone-assistant/SKILL.md
+++ b/skills/pinecone-assistant/SKILL.md
@@ -10,6 +10,8 @@ Pinecone Assistant is a fully managed RAG service. Upload documents, ask questio
 > All scripts are in `scripts/` relative to this skill directory.
 > Run with: `uv run scripts/script_name.py [arguments]`
 
+<<clarify_style>>
+
 ## Operations
 
 | What to do | Script | Key args |

--- a/skills/pinecone-assistant/SKILL.md
+++ b/skills/pinecone-assistant/SKILL.md
@@ -73,6 +73,7 @@ Handle chained requests naturally. Example:
 
 ## Prerequisites
 
-- `PINECONE_API_KEY` must be available — terminal: `export PINECONE_API_KEY="your-key"`, or add to a `.env` file and run scripts with `uv run --env-file .env scripts/...`
+- `PINECONE_API_KEY` must be available:
+<<api_key_setup>>
 - `uv` must be installed — [install uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Get a free API key at: https://app.pinecone.io/?sessionType=signup

--- a/skills/pinecone-assistant/scripts/context.py
+++ b/skills/pinecone-assistant/scripts/context.py
@@ -131,8 +131,7 @@ def main(
 
             # Suggest next action
             next_action = f"""[bold]Next steps:[/bold]
-• Ask a question: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
-• Upload more files: [cyan]uv run upload.py --assistant {assistant} --source PATH[/cyan]"""
+<<next_after_context>>"""
             console.print(Panel(next_action, title="What's Next?", border_style="green"))
 
     except AttributeError as e:
@@ -141,7 +140,7 @@ def main(
         console.print(f"[dim]Details: {e}[/dim]")
         console.print("\n[yellow]Note:[/yellow] Context API requires SDK version with assistant.context() support")
         console.print("\n[yellow]Try using chat instead:[/yellow]")
-        console.print(f"  uv run chat.py --assistant {assistant} --message \"{query}\"")
+        console.print(f"  <<next_chat_fallback>>")
         raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/skills/pinecone-assistant/scripts/create.py
+++ b/skills/pinecone-assistant/scripts/create.py
@@ -78,7 +78,7 @@ def main(
                 instructions=instructions if instructions else None,
                 region=region,
                 timeout=timeout,
-                metadata={"agentic-ide-source":"claude-code-plugin"}
+                metadata={"agentic-ide-source":"pinecone-skills"}
             )
 
         # Success message

--- a/skills/pinecone-assistant/scripts/create.py
+++ b/skills/pinecone-assistant/scripts/create.py
@@ -112,9 +112,7 @@ export PINECONE_ASSISTANT_HOST="{host}"
 
         # Next steps
         next_steps = f"""[bold]Next steps:[/bold]
-1. Upload files: [cyan]uv run upload.py --assistant {name} --source PATH[/cyan]
-2. Chat: [cyan]uv run chat.py --assistant {name} --message "YOUR QUESTION"[/cyan]
-3. Get context: [cyan]uv run context.py --assistant {name} --query "SEARCH TEXT"[/cyan]"""
+<<next_after_create>>"""
 
         console.print(Panel(next_steps, title="What's Next?", border_style="green"))
 

--- a/skills/pinecone-assistant/scripts/list.py
+++ b/skills/pinecone-assistant/scripts/list.py
@@ -61,7 +61,7 @@ def main(
             else:
                 console.print("[yellow]No assistants found.[/yellow]\n")
                 console.print("Create your first assistant with:")
-                console.print("  [cyan]uv run create.py --name ASSISTANT_NAME[/cyan]")
+                console.print("  <<next_create_first>>")
             return
 
         if json_output:
@@ -195,10 +195,7 @@ def main(
 
             # Next steps panel
             next_steps = """[bold]Next steps:[/bold]
-• List with files: [cyan]uv run list.py --files[/cyan]
-• Chat: [cyan]uv run chat.py --assistant NAME --message "YOUR QUESTION"[/cyan]
-• Upload: [cyan]uv run upload.py --assistant NAME --source PATH[/cyan]
-• Context: [cyan]uv run context.py --assistant NAME --query "SEARCH TEXT"[/cyan]"""
+<<next_commands>>"""
 
             console.print(Panel(next_steps, title="Available Commands", border_style="blue"))
 

--- a/skills/pinecone-assistant/scripts/upload.py
+++ b/skills/pinecone-assistant/scripts/upload.py
@@ -208,8 +208,7 @@ def main(
         # Next steps
         if uploaded > 0:
             next_steps = f"""[bold]Next steps:[/bold]
-• Chat: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
-• Context: [cyan]uv run context.py --assistant {assistant} --query "SEARCH TEXT"[/cyan]
+<<next_after_upload>>
 
 [dim]Note: Files are being processed and will be available shortly[/dim]"""
             console.print(Panel(next_steps, title="What's Next?", border_style="green"))

--- a/skills/pinecone-help/SKILL.md
+++ b/skills/pinecone-help/SKILL.md
@@ -9,6 +9,8 @@ Pinecone is the leading vector database for building accurate and performant AI 
 
 Here's everything you need to get started and a summary of all available skills.
 
+<<invoke_any_skill>>
+
 ---
 
 ## What You Need

--- a/skills/pinecone-help/SKILL.md
+++ b/skills/pinecone-help/SKILL.md
@@ -15,11 +15,9 @@ Here's everything you need to get started and a summary of all available skills.
 
 ### Required
 - **Pinecone account** — free to create at https://app.pinecone.io/?sessionType=signup
-- **API key** — create one in the Pinecone console after signing up, then either export it in your terminal:
-  ```bash
-  export PINECONE_API_KEY="your-key"
-  ```
-  Or add it to a `.env` file if your IDE doesn't inherit shell variables: `PINECONE_API_KEY=your-key`
+- **API key** — create one in the Pinecone console after signing up, then make it
+  available to this environment:
+  <<api_key_setup>>
 
 ### Optional (unlock more capabilities)
 

--- a/skills/pinecone-n8n/SKILL.md
+++ b/skills/pinecone-n8n/SKILL.md
@@ -5,6 +5,8 @@ description: Build n8n workflows using the Pinecone Assistant node or Pinecone V
 
 # Pinecone n8n Workflow Skill
 
+<<invoke_this_skill>>
+
 This skill helps you build n8n workflows with Pinecone nodes following best practices. It covers two Pinecone nodes:
 - **Pinecone Assistant** (`@pinecone-database/n8n-nodes-pinecone-assistant`) — recommended for most use cases
 - **Pinecone Vector Store** (`@n8n/n8n-nodes-langchain.vectorStorePinecone`) — for advanced control

--- a/skills/pinecone-query/SKILL.md
+++ b/skills/pinecone-query/SKILL.md
@@ -8,6 +8,8 @@ argument-hint: query [q] index [indexName] namespace [ns] topK [k] reranker [rer
 
 Search for records in Pinecone integrated indexes using natural language text queries via the Pinecone MCP server.
 
+<<clarify_style>>
+
 ## What is this skill for?
 
 This skill provides a simple way to query **integrated indexes** (indexes with built-in Pinecone embedding models) using text queries. The MCP server automatically converts your text into embeddings and searches the index.

--- a/skills/pinecone-query/SKILL.md
+++ b/skills/pinecone-query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinecone-query
-description: Query integrated indexes using text with Pinecone MCP. IMPORTANT - This skill ONLY works with integrated indexes (indexes with built-in Pinecone embedding models like multilingual-e5-large). For standard indexes or advanced vector operations, use the CLI skill instead. Requires PINECONE_API_KEY environment variable and Pinecone MCP server to be configured.
+description: Query integrated indexes using text with Pinecone MCP. IMPORTANT - This skill ONLY works with integrated indexes (indexes with built-in Pinecone embedding models like multilingual-e5-large). For standard indexes or advanced vector operations, use the pinecone-cli skill instead. Requires PINECONE_API_KEY environment variable and Pinecone MCP server to be configured.
 argument-hint: query [q] index [indexName] namespace [ns] topK [k] reranker [rerankModel]
 ---
 
@@ -21,13 +21,13 @@ This skill provides a simple way to query **integrated indexes** (indexes with b
 
 ### When NOT to use this skill
 
-**Use the CLI skill instead if:**
+**Use the pinecone-cli skill instead if:**
 - ❌ Your index is a standard index (no integrated embedding model)
 - ❌ You need to query with custom vector values (not text)
 - ❌ You need advanced vector operations (fetch by ID, list vectors, bulk operations)
 - ❌ Your index uses third-party embedding models (OpenAI, HuggingFace, Cohere)
 
-**MCP Limitation**: The Pinecone MCP currently only supports integrated indexes. For all other use cases, use the Pinecone CLI skill.
+**MCP Limitation**: The Pinecone MCP currently only supports integrated indexes. For all other use cases, use the pinecone-cli skill.
 
 ## How it works
 
@@ -61,10 +61,9 @@ Utilize Pinecone MCP's `search-records` tool to search for records within a spec
 **`PINECONE_API_KEY` is required.** Get a free key at https://app.pinecone.io/?sessionType=signup
 
 If you get an access error, the key is likely missing. Ask the user to set it and restart their IDE or agent session:
-- Terminal: `export PINECONE_API_KEY="your-key"`
-- IDE without shell inheritance: add `PINECONE_API_KEY=your-key` to a `.env` file
+<<api_key_setup>>
 
-**IMPORTANT** At the moment, the /query command can only be used with integrated indexes, which use hosted Pinecone embedding models to embed and search for data.
+**IMPORTANT** At the moment, the pinecone-query skill can only be used with integrated indexes, which use hosted Pinecone embedding models to embed and search for data.
 If a user attempts to query an index that uses a third party API model such as OpenAI, or HuggingFace embedding models, remind them that this capability is not available yet
 with the Pinecone MCP server.
 

--- a/skills/pinecone-quickstart/SKILL.md
+++ b/skills/pinecone-quickstart/SKILL.md
@@ -12,8 +12,7 @@ you will learn how to do a simple form of semantic search over some example data
 
 Before starting either path, verify the API key works by calling `list-indexes` via the Pinecone MCP. If it succeeds, proceed. If it fails, ask the user to set their key:
 
-- Terminal: `export PINECONE_API_KEY="your-key"`
-- Or create a `.env` file in the project root: `PINECONE_API_KEY=your-key`
+<<api_key_setup>>
 
 Then retry `list-indexes` to confirm.
 
@@ -150,7 +149,7 @@ Tell the user:
 
 ## Path B: Assistant Quickstart
 
-Guide the user through the Pinecone Assistant workflow using the existing assistant skills:
+Guide the user through the Pinecone Assistant workflow using the existing pinecone-assistant skill:
 
 ### Step 1 – Check for Documents
 
@@ -192,7 +191,7 @@ Explain: Responses include citations with source file and page number.
 ### Next Steps for Assistant
 
 - Invoke `pinecone-assistant` to keep the assistant up to date as documents change
-- Use the assistant skill to retrieve raw context snippets for custom workflows
+- Use the pinecone-assistant skill to retrieve raw context snippets for custom workflows
 - Every assistant is also an MCP server — see https://docs.pinecone.io/guides/assistant/mcp-server
 
 ---
@@ -201,15 +200,9 @@ Explain: Responses include citations with source file and page number.
 
 **`PINECONE_API_KEY` not set**
 
-Terminal environments:
-```bash
-export PINECONE_API_KEY="your-key"
-```
-IDEs that don't inherit shell variables: create a `.env` file in the project root:
-```
-PINECONE_API_KEY=your-key
-```
-Then use `uv run --env-file .env` when running scripts. Restart your IDE/agent session after setting.
+<<api_key_setup>>
+
+Restart your IDE or agent session after setting the key.
 
 **MCP tools not available**
 - Verify the Pinecone MCP server is configured in your IDE's MCP settings

--- a/skills/pinecone-quickstart/SKILL.md
+++ b/skills/pinecone-quickstart/SKILL.md
@@ -8,6 +8,8 @@ description: Interactive Pinecone quickstart for new developers. Choose between 
 Welcome! This skill walks you through your first Pinecone experience using the tools available to you. In this quickstart,
 you will learn how to do a simple form of semantic search over some example data.
 
+<<clarify_style>>
+
 ## Prerequisites
 
 Before starting either path, verify the API key works by calling `list-indexes` via the Pinecone MCP. If it succeeds, proceed. If it fails, ask the user to set their key:

--- a/targets/README.md
+++ b/targets/README.md
@@ -17,6 +17,8 @@ three agents and three different answers to the same question.
 | `skill_name` | Template for the `name:` frontmatter value. |
 | `cross_reference` | Template for how prose refers to *another* skill. See the rule below. |
 | `source_tag` | Replaces `pinecone_skills` in the `source_tag=` argument inside `.py` files. |
+| `ide_source` | Replaces `pinecone-skills` in the `agentic-ide-source` metadata value inside `.py` files. |
+| `snippets` | Wording for the `<<name>>` markers in base. See "Snippets" below. |
 | `include` | Slugs to render. Explicit, so adding a skill to base does not silently publish it everywhere. |
 | `frontmatter` | Per-slug keys this target adds. Emitted after `argument-hint`. |
 
@@ -72,6 +74,62 @@ This distinction is not theoretical. `pinecone-quickstart/SKILL.md` carries thre
 such paths, and running them through `cross_reference` emitted
 `../pinecone:assistant/scripts/create.py` — a path that cannot exist on any
 filesystem. It was caught by `tools/reconcile.py`, not by unit tests.
+
+## Snippets
+
+Some things really do differ per plugin, and base cannot state both. Cursor reads
+`.env` through its own MCP config; Claude Code reads your shell. Claude Code has
+working slash commands; Cursor declares none. Before this, an agent ran inside each
+plugin repo and worked the difference out, giving a slightly different answer every
+run. A snippet states it once.
+
+Base leaves a marker:
+
+```markdown
+- **API key** — create one in the console, then make it available:
+  <<api_key_setup>>
+```
+
+Each manifest fills it:
+
+```yaml
+snippets:
+  api_key_setup: |
+    - Add `PINECONE_API_KEY=your-key` to a `.env` file at your workspace root. The
+      bundled MCP config reads it through Cursor's `envFile` field.
+```
+
+### Rules
+
+- Marker syntax is `<<lower_snake_name>>`. **Not** `{{ name }}` — `pinecone-n8n`
+  is full of real n8n expressions like `={{ $json.urls }}`, and a marker shaped
+  like one would confuse the build and the next person to edit that file.
+- Every marker in base must be defined by **every** target, or the build fails.
+  A skill published with `<<api_key_setup>>` visible in the text is worse than
+  either wording.
+- Every defined snippet must be used by some included skill, or the build fails.
+  This is the half that is easy to forget: stale wording sitting in a manifest
+  looks authoritative.
+- Snippets fill **first**, before path and cross-reference rewriting. So snippet
+  text passes through the same guards as base content — write `pinecone-cli` in a
+  snippet and it retargets correctly.
+- Trailing newlines are stripped, so `|` block scalars sit cleanly inline.
+
+### Writing snippets that land inside Python
+
+Markers in `.py` files sit inside string literals. A snippet that ends with a `"`
+directly before a closing `"""` produces a file that cannot be imported.
+
+`check_python_syntax` catches this — every rendered `.py` must parse. Do not rely
+on review for it. The current script snippets avoid decorative quotes for this
+reason, which is a small, deliberate cosmetic difference from what the Claude
+plugin shipped by hand.
+
+### When to add one
+
+Only where the plugins truly differ. Five of nine skills need no snippet at all,
+and a blank in the middle of a sentence is cheaper than forking a file. If the same
+wording is right everywhere, put it in base.
 
 ## Reconciling against the live repos
 

--- a/targets/claude-code.yaml
+++ b/targets/claude-code.yaml
@@ -104,3 +104,10 @@ snippets:
     Whenever this skill asks the user to choose between options, confirm a
     destructive step, or pick from a list, use the AskUserQuestion tool rather
     than plain prose. Fall back to prose only if the tool is unavailable.
+
+  # Claude Code exposes each skill as `/pinecone:<slug>`. The live plugin never said
+  # so; Cursor's copy did, which is where these two lines come from.
+  invoke_any_skill: >
+    Invoke any skill from chat with `/pinecone:<skill-name>` — for example
+    `/pinecone:quickstart` or `/pinecone:n8n`.
+  invoke_this_skill: "Invoke this skill from chat with `/pinecone:n8n`."

--- a/targets/claude-code.yaml
+++ b/targets/claude-code.yaml
@@ -63,3 +63,37 @@ frontmatter:
     allowed-tools: "Bash, Read"
   quickstart:
     allowed-tools: "Skill(pinecone:assistant *), Bash, Read"
+
+# Per-target wording for the `<<name>>` markers in base. See targets/README.md.
+#
+# Claude Code has working slash commands and reads your shell environment, so this
+# target keeps both. The live plugin already said this; base cannot, because the
+# same sentences are wrong for Cursor.
+snippets:
+  api_key_setup: |
+    - Run `export PINECONE_API_KEY="your-key"` in your terminal. Claude Code reads
+      your shell environment, so this is enough.
+    - To use a `.env` file instead, run scripts with `uv run --env-file .env scripts/...`.
+
+  next_after_create: |
+    1. Upload files: [cyan]/pinecone:assistant[/cyan] — upload files from [path] to {name}
+    2. Chat: [cyan]/pinecone:assistant[/cyan] — ask {name} about [your question]
+    3. Get context: [cyan]/pinecone:assistant[/cyan] — search {name} for context about [topic]
+
+  next_create_first: "[cyan]/pinecone:assistant[/cyan] — create a new assistant called [name]"
+
+  next_commands: |
+    • List with files: [cyan]/pinecone:assistant[/cyan] — list my assistants with their files
+    • Chat: [cyan]/pinecone:assistant[/cyan] — ask [name] about [your question]
+    • Upload: [cyan]/pinecone:assistant[/cyan] — upload files from [path] to [name]
+    • Context: [cyan]/pinecone:assistant[/cyan] — search [name] for context about [topic]
+
+  next_after_upload: |
+    • Chat: [cyan]/pinecone:assistant[/cyan] — ask {assistant} about [your question]
+    • Context: [cyan]/pinecone:assistant[/cyan] — search {assistant} for context about [topic]
+
+  next_after_context: |
+    • Ask a question: [cyan]/pinecone:assistant[/cyan] — ask {assistant} about [your question]
+    • Upload more files: [cyan]/pinecone:assistant[/cyan] — upload files from [path] to {assistant}
+
+  next_chat_fallback: '/pinecone:assistant — ask {assistant} about \"{query}\"'

--- a/targets/claude-code.yaml
+++ b/targets/claude-code.yaml
@@ -97,3 +97,10 @@ snippets:
     • Upload more files: [cyan]/pinecone:assistant[/cyan] — upload files from [path] to {assistant}
 
   next_chat_fallback: '/pinecone:assistant — ask {assistant} about \"{query}\"'
+
+  # This target has a real tool for structured choices, so it says so once here
+  # rather than at each of the fifteen places a skill asks the user something.
+  clarify_style: >
+    Whenever this skill asks the user to choose between options, confirm a
+    destructive step, or pick from a list, use the AskUserQuestion tool rather
+    than plain prose. Fall back to prose only if the tool is unavailable.

--- a/targets/claude-code.yaml
+++ b/targets/claude-code.yaml
@@ -23,6 +23,11 @@ cross_reference: "pinecone:{slug}"
 # Replaces `pinecone_skills:` in the source_tag argument inside .py files.
 source_tag: claude_code_plugin
 
+# Replaces `pinecone-skills` in the `agentic-ide-source` metadata value that
+# pinecone-assistant/scripts/create.py stamps on each assistant it creates.
+# Same shape as source_tag, different consumer.
+ide_source: claude-code-plugin
+
 include:
   - assistant
   - cli

--- a/targets/cursor.yaml
+++ b/targets/cursor.yaml
@@ -78,3 +78,9 @@ snippets:
     • Upload more files: [cyan]uv run upload.py --assistant {assistant} --source PATH[/cyan]
 
   next_chat_fallback: 'uv run chat.py --assistant {assistant} --message \"{query}\"'
+
+  # No structured-choice tool here, so say what to do instead.
+  clarify_style: >
+    Whenever this skill asks the user to choose between options, confirm a
+    destructive step, or pick from a list, ask in plain prose, list the options,
+    and wait for their answer before continuing.

--- a/targets/cursor.yaml
+++ b/targets/cursor.yaml
@@ -23,6 +23,11 @@ cross_reference: "pinecone-{slug}"
 
 source_tag: cursor_plugin
 
+# Replaces `pinecone-skills` in the `agentic-ide-source` metadata value that
+# pinecone-assistant/scripts/create.py stamps on each assistant it creates.
+# Same shape as source_tag, different consumer.
+ide_source: cursor-plugin
+
 include:
   - assistant
   - cli

--- a/targets/cursor.yaml
+++ b/targets/cursor.yaml
@@ -42,3 +42,39 @@ include:
 # Cursor adds no per-skill frontmatter. Verified: 0 of 9 live skills carry
 # allowed-tools.
 frontmatter: {}
+
+# Per-target wording for the `<<name>>` markers in base. See targets/README.md.
+#
+# Two things drive these. The bundled MCP config reads `.env` through Cursor's
+# `envFile` field, which is worth saying plainly. And Cursor declares no slash
+# commands, so the scripts name the commands you can actually run — the live
+# plugin advertised `/pinecone:assistant-chat` and friends, none of which exist.
+snippets:
+  api_key_setup: |
+    - Add `PINECONE_API_KEY=your-key` to a `.env` file at your workspace root. The
+      bundled MCP config reads it through Cursor's `envFile` field.
+    - For scripts, either `export PINECONE_API_KEY="your-key"` in your terminal or
+      run them with `uv run --env-file .env scripts/...`.
+
+  next_after_create: |
+    1. Upload files: [cyan]uv run upload.py --assistant {name} --source PATH[/cyan]
+    2. Chat: [cyan]uv run chat.py --assistant {name} --message "YOUR QUESTION"[/cyan]
+    3. Get context: [cyan]uv run context.py --assistant {name} --query "SEARCH TEXT"[/cyan]
+
+  next_create_first: "[cyan]uv run create.py --name ASSISTANT_NAME[/cyan]"
+
+  next_commands: |
+    • List with files: [cyan]uv run list.py --files[/cyan]
+    • Chat: [cyan]uv run chat.py --assistant NAME --message "YOUR QUESTION"[/cyan]
+    • Upload: [cyan]uv run upload.py --assistant NAME --source PATH[/cyan]
+    • Context: [cyan]uv run context.py --assistant NAME --query "SEARCH TEXT"[/cyan]
+
+  next_after_upload: |
+    • Chat: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
+    • Context: [cyan]uv run context.py --assistant {assistant} --query "SEARCH TEXT"[/cyan]
+
+  next_after_context: |
+    • Ask a question: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
+    • Upload more files: [cyan]uv run upload.py --assistant {assistant} --source PATH[/cyan]
+
+  next_chat_fallback: 'uv run chat.py --assistant {assistant} --message \"{query}\"'

--- a/targets/cursor.yaml
+++ b/targets/cursor.yaml
@@ -84,3 +84,11 @@ snippets:
     Whenever this skill asks the user to choose between options, confirm a
     destructive step, or pick from a list, ask in plain prose, list the options,
     and wait for their answer before continuing.
+
+  # Cursor exposes each skill under its own name, `pinecone-<slug>`. Confirmed in
+  # Cursor 2026-08-10. Distinct from the `/pinecone:assistant-chat` commands the
+  # scripts used to advertise, which were never declared anywhere and did not exist.
+  invoke_any_skill: >
+    Invoke any skill from Cursor Agent chat with `/pinecone-<skill-name>` — for
+    example `/pinecone-quickstart` or `/pinecone-n8n`.
+  invoke_this_skill: "Invoke this skill from Cursor Agent chat with `/pinecone-n8n`."

--- a/tools/build.py
+++ b/tools/build.py
@@ -40,6 +40,13 @@ DIST_DIR = REPO / "dist"
 BASE_PREFIX = "pinecone-"
 NEUTRAL_SOURCE_TAG = "pinecone_skills"
 
+# The assistant create script stamps this metadata key on every assistant it makes.
+# It is a second per-target value with the same shape as source_tag, and it was
+# missed for months: base hardcoded `claude-code-plugin`, so a sync would have
+# labelled Cursor-created assistants as Claude Code.
+IDE_SOURCE_KEY = "agentic-ide-source"
+NEUTRAL_IDE_SOURCE = "pinecone-skills"
+
 # Frontmatter keys, in the order the build must emit them. `allowed-tools` comes
 # from the manifest and is appended last; the rest pass through from base.
 FRONTMATTER_ORDER = ["name", "description", "argument-hint", "allowed-tools"]
@@ -54,7 +61,8 @@ def load_manifest(target: str) -> dict[str, Any]:
     if not path.exists():
         raise typer.BadParameter(f"no manifest at {path.relative_to(REPO)}")
     m = yaml.safe_load(path.read_text())
-    for key in ("repo", "skills_path", "dir_name", "skill_name", "cross_reference", "source_tag", "include"):
+    for key in ("repo", "skills_path", "dir_name", "skill_name", "cross_reference",
+                "source_tag", "ide_source", "include"):
         if key not in m:
             raise ValueError(f"{target}.yaml is missing required key: {key}")
     m.setdefault("frontmatter", {}) or m.__setitem__("frontmatter", m.get("frontmatter") or {})
@@ -139,6 +147,28 @@ def rewrite_source_tag(text: str, manifest: dict[str, Any]) -> str:
     )
 
 
+IDE_SOURCE_RE = re.compile(rf'("{re.escape(IDE_SOURCE_KEY)}"\s*:\s*")([^"]*)(")')
+
+
+def rewrite_ide_source(text: str, manifest: dict[str, Any], path: Path) -> str:
+    """Retarget the `agentic-ide-source` metadata value inside .py files.
+
+    Strict on purpose. Base must hold the neutral value, so anything else means a
+    target name has been hardcoded into shared source again. Silently overwriting
+    it would hide the very drift this rule exists to stop.
+    """
+    def repl(match: re.Match[str]) -> str:
+        found = match.group(2)
+        if found not in (NEUTRAL_IDE_SOURCE, manifest["ide_source"]):
+            raise ValueError(
+                f"{path}: {IDE_SOURCE_KEY} is {found!r}; base must use "
+                f"{NEUTRAL_IDE_SOURCE!r} so each target can set its own"
+            )
+        return match.group(1) + manifest["ide_source"] + match.group(3)
+
+    return IDE_SOURCE_RE.sub(repl, text)
+
+
 def split_frontmatter(text: str, path: Path) -> tuple[dict[str, str], str]:
     """Return (frontmatter dict, body). Preserves value strings verbatim."""
     if not text.startswith("---\n"):
@@ -191,7 +221,7 @@ def render_file(rel: Path, text: str, slug: str, manifest: dict[str, Any], path:
     if rel.name == "SKILL.md":
         return render_skill_md(text, slug, manifest, path)
     if rel.suffix == ".py":
-        return rewrite_source_tag(text, manifest)
+        return rewrite_ide_source(rewrite_source_tag(text, manifest), manifest, path)
     if rel.suffix == ".md":
         return rewrite_cross_references(text, manifest)
     return text
@@ -237,9 +267,22 @@ def build_target(target: str, out_root: Path | None = None) -> tuple[Path, int]:
 # checks
 # --------------------------------------------------------------------------- #
 
+def permitted_line_changes(manifest: dict[str, Any]) -> list[tuple[str, str]]:
+    """(marker in base, value in rendered) pairs the identity check tolerates.
+
+    Every per-target scalar belongs here. Leaving one out makes the identity check
+    fail on a legitimate rewrite; adding one loosely makes it blind to a real
+    change. Keep it to exact neutral markers.
+    """
+    return [
+        (NEUTRAL_SOURCE_TAG, manifest["source_tag"]),
+        (NEUTRAL_IDE_SOURCE, manifest["ide_source"]),
+    ]
+
+
 def check_identity_target(target: str, out_root: Path | None = None) -> list[str]:
     """For a target whose dir_name and skill_name equal base, rendered output must
-    be byte-identical to base except for source_tag lines.
+    be byte-identical to base except for the per-target scalars above.
 
     This is the cheapest possible regression test for such a target — it replaces
     a paid eval run with an exact comparison.
@@ -265,24 +308,32 @@ def check_identity_target(target: str, out_root: Path | None = None) -> list[str
             if len(a) != len(b):
                 problems.append(f"{target}: line count differs for {slug}/{rel}")
                 continue
+            permitted = permitted_line_changes(manifest)
             for i, (la, lb) in enumerate(zip(a, b), 1):
                 if la == lb:
                     continue
-                if NEUTRAL_SOURCE_TAG in la and manifest["source_tag"] in lb:
-                    continue                     # the one permitted difference
+                if any(marker in la and value in lb for marker, value in permitted):
+                    continue                     # a declared per-target scalar
                 problems.append(f"{target}: unexpected change at {slug}/{rel}:{i}\n    - {la}\n    + {lb}")
     return problems
 
 
 def check_no_neutral_tags(target: str, out_root: Path | None = None) -> list[str]:
-    """No rendered output may still carry the neutral source tag."""
+    """No rendered output may still carry a neutral per-target marker.
+
+    Catches the case where base grows a new site the rewrite rules do not reach —
+    a new script, or the same field written with different spacing.
+    """
     manifest = load_manifest(target)
     out = (out_root or DIST_DIR) / target / manifest["skills_path"]
-    return [
-        f"{target}: {p.relative_to(out)} still contains {NEUTRAL_SOURCE_TAG}:"
-        for p in out.rglob("*.py")
-        if f"{NEUTRAL_SOURCE_TAG}:" in p.read_text()
-    ]
+    problems: list[str] = []
+    for p in sorted(out.rglob("*.py")):
+        text = p.read_text()
+        if f"{NEUTRAL_SOURCE_TAG}:" in text:
+            problems.append(f"{target}: {p.relative_to(out)} still contains {NEUTRAL_SOURCE_TAG}:")
+        if NEUTRAL_IDE_SOURCE in text:
+            problems.append(f"{target}: {p.relative_to(out)} still contains {NEUTRAL_IDE_SOURCE}")
+    return problems
 
 
 def check_idempotent(target: str, tmp_root: Path) -> list[str]:

--- a/tools/build.py
+++ b/tools/build.py
@@ -21,6 +21,7 @@ See targets/README.md for the manifest schema and the transform rules.
 
 from __future__ import annotations
 
+import ast
 import filecmp
 import re
 import shutil
@@ -46,6 +47,12 @@ NEUTRAL_SOURCE_TAG = "pinecone_skills"
 # labelled Cursor-created assistants as Claude Code.
 IDE_SOURCE_KEY = "agentic-ide-source"
 NEUTRAL_IDE_SOURCE = "pinecone-skills"
+
+# Snippet markers. `<<name>>` and not `{{ name }}`: pinecone-n8n/SKILL.md is full of
+# real n8n expressions like `={{ $json.urls }}`, and a marker that looks like one
+# would confuse both the build and whoever edits that file next. `<<` appears
+# nowhere in base.
+SNIPPET_RE = re.compile(r"<<([a-z][a-z0-9_]*)>>")
 
 # Frontmatter keys, in the order the build must emit them. `allowed-tools` comes
 # from the manifest and is appended last; the rest pass through from base.
@@ -169,6 +176,32 @@ def rewrite_ide_source(text: str, manifest: dict[str, Any], path: Path) -> str:
     return IDE_SOURCE_RE.sub(repl, text)
 
 
+def fill_snippets(text: str, manifest: dict[str, Any], path: Path) -> str:
+    """Replace `<<name>>` with the target's wording for that name.
+
+    This is the declared replacement for the agent that used to rewrite skills
+    inside each plugin repo. Some things really do differ per plugin — Cursor reads
+    `.env` through its own MCP config, Claude Code has working slash commands — and
+    base cannot state both. An agent inferred the difference and gave a slightly
+    different answer every run. A snippet states it once, in a file you can review.
+
+    Undefined names are a hard error. A skill published with `<<api_key_setup>>`
+    sitting in the text would be worse than either wording.
+    """
+    snippets = manifest.get("snippets") or {}
+
+    def repl(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in snippets:
+            raise ValueError(
+                f"{path}: no snippet {name!r} for this target. Define it in "
+                f"targets/*.yaml for every target, or remove the marker from base."
+            )
+        return str(snippets[name]).strip()
+
+    return SNIPPET_RE.sub(repl, text)
+
+
 def split_frontmatter(text: str, path: Path) -> tuple[dict[str, str], str]:
     """Return (frontmatter dict, body). Preserves value strings verbatim."""
     if not text.startswith("---\n"):
@@ -218,6 +251,10 @@ def render_skill_md(text: str, slug: str, manifest: dict[str, Any], path: Path) 
 
 
 def render_file(rel: Path, text: str, slug: str, manifest: dict[str, Any], path: Path) -> str:
+    # Snippets first, deliberately. Their text can contain skill names and paths, so
+    # filling them before the other rules run means snippet content passes through
+    # the same guards as base content instead of going around them.
+    text = fill_snippets(text, manifest, path)
     if rel.name == "SKILL.md":
         return render_skill_md(text, slug, manifest, path)
     if rel.suffix == ".py":
@@ -303,7 +340,11 @@ def check_identity_target(target: str, out_root: Path | None = None) -> list[str
             if not other.exists():
                 problems.append(f"{target}: missing {rel} under {slug}")
                 continue
-            a = path.read_text().splitlines()
+            # Fill snippets on the base side too. Snippets are a declared per-target
+            # difference, and a multi-line one would otherwise trip the line-count
+            # comparison below. What this still asserts is the valuable part: no
+            # *other* rule changed anything for an identity target.
+            a = fill_snippets(path.read_text(), manifest, path).splitlines()
             b = other.read_text().splitlines()
             if len(a) != len(b):
                 problems.append(f"{target}: line count differs for {slug}/{rel}")
@@ -333,6 +374,56 @@ def check_no_neutral_tags(target: str, out_root: Path | None = None) -> list[str
             problems.append(f"{target}: {p.relative_to(out)} still contains {NEUTRAL_SOURCE_TAG}:")
         if NEUTRAL_IDE_SOURCE in text:
             problems.append(f"{target}: {p.relative_to(out)} still contains {NEUTRAL_IDE_SOURCE}")
+    return problems
+
+
+def check_python_syntax(target: str, out_root: Path | None = None) -> list[str]:
+    """Every rendered .py file must parse.
+
+    Snippets land inside string literals, so a snippet that ends with a quote next
+    to a closing triple quote produces a file that cannot be imported. Nothing else
+    in the build would notice: the bytes look fine and only Python objects. Users
+    would find it. This check finds it first.
+    """
+    manifest = load_manifest(target)
+    out = (out_root or DIST_DIR) / target / manifest["skills_path"]
+    problems = []
+    for path in sorted(out.rglob("*.py")):
+        try:
+            ast.parse(path.read_text())
+        except SyntaxError as exc:
+            problems.append(f"{target}: {path.relative_to(out)} does not parse — {exc}")
+    return problems
+
+
+def check_snippets(target: str) -> list[str]:
+    """Snippet definitions and markers must agree, in both directions.
+
+    Missing definitions already fail during render. This catches the quieter half:
+    a snippet defined in a manifest that base no longer references. Left unchecked,
+    stale wording sits in the manifest looking authoritative for months.
+    """
+    manifest = load_manifest(target)
+    defined = set(manifest.get("snippets") or {})
+    referenced: set[str] = set()
+    for slug in manifest["include"]:
+        src = SKILLS_DIR / f"{BASE_PREFIX}{slug}"
+        for path in sorted(src.rglob("*")):
+            if path.is_dir() or "__pycache__" in path.parts:
+                continue
+            try:
+                referenced |= set(SNIPPET_RE.findall(path.read_text()))
+            except UnicodeDecodeError:
+                continue
+
+    problems = [
+        f"{target}: snippet {name!r} is defined but no included skill uses <<{name}>>"
+        for name in sorted(defined - referenced)
+    ]
+    problems += [
+        f"{target}: base uses <<{name}>> but targets/{target}.yaml does not define it"
+        for name in sorted(referenced - defined)
+    ]
     return problems
 
 
@@ -374,6 +465,8 @@ def main(
         typer.echo(f"built {t}: {n} files -> {path.relative_to(REPO) if not out_root else path}")
         problems += check_no_neutral_tags(t, out_root)
         problems += check_identity_target(t, out_root)
+        problems += check_snippets(t)
+        problems += check_python_syntax(t, out_root)
         if check:
             import tempfile
             with tempfile.TemporaryDirectory() as tmp:

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -28,9 +28,9 @@ import build  # noqa: E402
 
 SLUGS = ["assistant", "cli", "docs", "full-text-search", "help", "mcp", "n8n", "query", "quickstart"]
 CLAUDE = {"include": SLUGS, "cross_reference": "pinecone:{slug}", "dir_name": "{slug}",
-          "source_tag": "claude_code_plugin"}
+          "source_tag": "claude_code_plugin", "ide_source": "claude-code-plugin"}
 CURSOR = {"include": SLUGS, "cross_reference": "pinecone-{slug}", "dir_name": "pinecone-{slug}",
-          "source_tag": "cursor_plugin"}
+          "source_tag": "cursor_plugin", "ide_source": "cursor-plugin"}
 
 
 def xref(text, manifest=CLAUDE):
@@ -128,6 +128,47 @@ class TestSourceTag:
     def test_leaves_an_already_targeted_tag_alone(self):
         line = 'source_tag="claude_code_plugin:assistant"'
         assert build.rewrite_source_tag(line, CURSOR) == line
+
+
+class TestIdeSource:
+    """The real bug this rule fixes: base hardcoded `claude-code-plugin`, so a sync
+    would have stamped every Cursor-created assistant as Claude Code."""
+
+    LINE = 'metadata={"agentic-ide-source":"pinecone-skills"}'
+
+    def test_retargets_for_claude(self):
+        out = build.rewrite_ide_source(self.LINE, CLAUDE, Path("x"))
+        assert out == 'metadata={"agentic-ide-source":"claude-code-plugin"}'
+
+    def test_retargets_for_cursor(self):
+        out = build.rewrite_ide_source(self.LINE, CURSOR, Path("x"))
+        assert out == 'metadata={"agentic-ide-source":"cursor-plugin"}'
+
+    def test_tolerates_spacing(self):
+        line = 'metadata={"agentic-ide-source": "pinecone-skills"}'
+        assert 'cursor-plugin' in build.rewrite_ide_source(line, CURSOR, Path("x"))
+
+    def test_already_targeted_is_idempotent(self):
+        line = 'metadata={"agentic-ide-source":"cursor-plugin"}'
+        assert build.rewrite_ide_source(line, CURSOR, Path("x")) == line
+
+    def test_a_foreign_target_name_is_an_error(self):
+        """Base drifting back to a hardcoded target name must fail the build, not be
+        silently overwritten — silence is how this survived the first time."""
+        line = 'metadata={"agentic-ide-source":"claude-code-plugin"}'
+        with pytest.raises(ValueError, match="base must use"):
+            build.rewrite_ide_source(line, CURSOR, Path("x"))
+
+    def test_py_dispatch_applies_both_scalars(self):
+        text = 'source_tag="pinecone_skills:assistant"\n{"agentic-ide-source":"pinecone-skills"}\n'
+        out = build.render_file(Path("scripts/create.py"), text, "assistant", CURSOR, Path("x"))
+        assert "cursor_plugin:assistant" in out
+        assert "cursor-plugin" in out
+        assert "pinecone-skills" not in out
+
+    def test_ide_source_value_is_not_eaten_by_cross_references(self):
+        """`pinecone-skills` is not a slug, so no rule should touch it in prose."""
+        assert xref("pinecone-skills") == "pinecone-skills"
 
 
 class TestFrontmatter:

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -130,6 +130,55 @@ class TestSourceTag:
         assert build.rewrite_source_tag(line, CURSOR) == line
 
 
+class TestSnippets:
+    """Snippets carry the wording that really does differ per plugin. They replaced
+    an agent that inferred the same difference and answered differently each run."""
+
+    CL = dict(CLAUDE, snippets={"api_key_setup": "export it in your shell"})
+    CU = dict(CURSOR, snippets={"api_key_setup": "add it to a `.env` file"})
+
+    def test_fills_per_target(self):
+        src = "Set the key: <<api_key_setup>>\n"
+        assert build.fill_snippets(src, self.CL, Path("x")) == "Set the key: export it in your shell\n"
+        assert build.fill_snippets(src, self.CU, Path("x")) == "Set the key: add it to a `.env` file\n"
+
+    def test_multiple_markers_in_one_file(self):
+        m = dict(self.CL, snippets={"a": "AAA", "b": "BBB"})
+        assert build.fill_snippets("<<a>> then <<b>>", m, Path("x")) == "AAA then BBB"
+
+    def test_undefined_marker_is_an_error(self):
+        """Publishing a skill with `<<api_key_setup>>` in the text is worse than
+        either wording, so this must fail rather than pass the marker through."""
+        with pytest.raises(ValueError, match="no snippet 'mystery'"):
+            build.fill_snippets("<<mystery>>", self.CL, Path("x"))
+
+    def test_trailing_newline_is_stripped(self):
+        m = dict(self.CL, snippets={"a": "one\ntwo\n"})
+        assert build.fill_snippets("<<a>>\nafter", m, Path("x")) == "one\ntwo\nafter"
+
+    def test_n8n_expressions_are_not_markers(self):
+        """pinecone-n8n/SKILL.md is full of `={{ $json.urls }}`. Nothing may touch it."""
+        src = '"url": "={{ $json.urls }}",\n'
+        assert build.fill_snippets(src, self.CL, Path("x")) == src
+
+    def test_no_marker_no_snippets_defined_is_fine(self):
+        assert build.fill_snippets("plain text", CLAUDE, Path("x")) == "plain text"
+
+    def test_snippet_content_goes_through_the_other_rules(self):
+        """Snippets fill first on purpose, so their text passes through the same
+        guards as base content rather than around them."""
+        m = dict(CLAUDE, skill_name="pinecone:{slug}", frontmatter={},
+                 snippets={"hint": "see pinecone-cli and ../pinecone-assistant/scripts/x.py"})
+        out = build.render_file(Path("references/a.md"), "<<hint>>\n", "docs", m, Path("x"))
+        assert out == "see pinecone:cli and ../assistant/scripts/x.py\n"
+
+    def test_identity_target_snippet_is_not_retargeted(self):
+        m = dict(CURSOR, skill_name="pinecone-{slug}", frontmatter={},
+                 snippets={"hint": "see pinecone-cli and ../pinecone-assistant/scripts/x.py"})
+        out = build.render_file(Path("references/a.md"), "<<hint>>\n", "docs", m, Path("x"))
+        assert out == "see pinecone-cli and ../pinecone-assistant/scripts/x.py\n"
+
+
 class TestIdeSource:
     """The real bug this rule fixes: base hardcoded `claude-code-plugin`, so a sync
     would have stamped every Cursor-created assistant as Claude Code."""


### PR DESCRIPTION
Two things the plugins need that base could not express, and one outright bug.

## Bug: `agentic-ide-source` was hardcoded

`pinecone-assistant/scripts/create.py` stamps this metadata key on every assistant
it creates. Base held `claude-code-plugin`, so a build for any other target
mislabelled the assistants it made. Adds an `ide_source` manifest field alongside
`source_tag`. Base now holds a neutral value, and a target name appearing there
again fails the build rather than being silently overwritten.

## Snippets: per-target wording, declared instead of inferred

Some sentences are correct for one target and wrong for another. Cursor reads
`.env` through its own MCP config; Claude Code reads the shell. Claude Code has
working slash commands. Base cannot state both, and picking a middle wording made
the text vague enough to be useless in either.

Base leaves a marker; each file in `targets/` supplies the wording:

```markdown
- **API key** — create one in the console, then make it available:
  <<api_key_setup>>
```

```yaml
snippets:
  api_key_setup: |
    - Add `PINECONE_API_KEY=your-key` to a `.env` file at your workspace root. The
      bundled MCP config reads it through Cursor's `envFile` field.
```

16 markers across 6 skills, covering the API key instructions, the next-step hints
the assistant scripts print, how to invoke a skill, and whether to use a structured
picker or plain prose. Three skills need no markers.

Two build checks keep it honest, in both directions: a marker no target defines
fails, and a snippet no skill uses fails. Stale wording in a manifest looks
authoritative, so the second half matters as much as the first.

Marker syntax is `<<name>>` rather than `{{ name }}` because `pinecone-n8n` is full
of real n8n expressions like `={{ $json.urls }}`.

## Also

- Skill references written as slugs (`pinecone-cli`, not "the CLI skill") so the
  existing rename rule reaches them. An agent can act on a slug.
- New check: every rendered `.py` file must parse. Markers sit inside string
  literals, so a snippet ending in a quote next to a closing `"""` produces a file
  that cannot be imported, and nothing else in the build would notice.
- `CLAUDE.md` updated. Base still must not name IDE-specific tools directly, but a
  snippet is now the documented way to keep one where it is the right answer. The
  previous flat ban dropped a working feature at 15 sites.

## Verification

- 54 tests, up from 39.
- `uv run tools/build.py --all --check` passes: cursor stays byte-identical to base
  apart from declared per-target values, no neutral marker survives into output,
  two builds produce identical bytes, and every rendered script parses.
- Rendered output diffed file by file against both published plugins. The syntax
  check was confirmed by deliberately breaking a snippet.
