### PR TITLE
chore: pin tool dependencies exactly

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
+# Pinned exactly, not floating. These install at CI job time in a job that holds a
+# write token for the plugin repos, so a compromised release would run there. The
+# same floating-lower-bound habit is what let pinecone 9 break every skill script.
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "pyyaml>=6.0",
-#   "typer>=0.15.0",
+#   "pyyaml==6.0.3",
+#   "typer==0.27.1",
 # ]
 # ///
 """Render skills/ into dist/<target>/ using a target manifest.

--- a/tools/reconcile.py
+++ b/tools/reconcile.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
+# Pinned exactly, not floating. These install at CI job time in a job that holds a
+# write token for the plugin repos, so a compromised release would run there. The
+# same floating-lower-bound habit is what let pinecone 9 break every skill script.
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "pyyaml>=6.0",
-#   "typer>=0.15.0",
+#   "pyyaml==6.0.3",
+#   "typer==0.27.1",
 # ]
 # ///
 """Diff a rendered target tree against the live plugin repo.

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
+# Pinned exactly, not floating. These install at CI job time in a job that holds a
+# write token for the plugin repos, so a compromised release would run there. The
+# same floating-lower-bound habit is what let pinecone 9 break every skill script.
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "pytest>=8.0",
-#   "pyyaml>=6.0",
-#   "typer>=0.15.0",
+#   "pytest==9.1.1",
+#   "pyyaml==6.0.3",
+#   "typer==0.27.1",
 # ]
 # ///
 """Tests for tools/build.py.


### PR DESCRIPTION
Pins the `tools/` scripts to exact dependency versions instead of floating lower
bounds.

```
- "pyyaml>=6.0"        + "pyyaml==6.0.3"
- "typer>=0.15.0"      + "typer==0.27.1"
- "pytest>=8.0"        + "pytest==9.1.1"
```

These are PEP 723 inline dependencies, so `uv run` resolves them fresh on every
invocation, including in CI. A lower bound means the resolved version can change
without any commit here.

Two reasons that matters:

- **Reproducibility.** `build.py` is meant to be a pure function of `skills/` plus
  a target manifest. If its own dependencies float, the output is a function of the
  resolution date too.
- **Supply chain.** The sync job runs these scripts while holding a credential that
  can write to the plugin repositories. A floating bound means a newly published
  release executes there.

Also documents the reasoning in each file, so the pins do not get relaxed as
housekeeping later.

Verified against the pinned versions: `tools/build.py --all --check` passes, 54
tests pass, `tools/reconcile.py` runs.
