### PR TITLE
docs: correct wording after cutover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # Skills Repo — Authoring Guidelines
 
-This is the **base skills repo**. Skills here must work across any agent environment (Claude Code, Cursor, Gemini, etc.). IDE-specific repos fork from here and contextualize as needed.
+This is the **base skills repo** and the only place skills are authored. Skills here must work across any agent environment (Claude Code, Cursor, etc.).
+
+Plugin repos receive generated output. `tools/build.py` renders this tree per target using the manifests in `targets/`, and the sync workflow opens a pull request against each plugin repo. Nothing rewrites skills after they leave here, so what you write is what ships. Where a target genuinely needs different wording, base leaves a `<<marker>>` and each file in `targets/` supplies its own text — see `targets/README.md`.
 
 ## Generalization Rules
 

--- a/targets/README.md
+++ b/targets/README.md
@@ -3,9 +3,10 @@
 One YAML per publish target. `tools/build.py` reads `skills/` plus a manifest and
 renders `dist/<target>/`. The build is a pure function: same inputs, same bytes.
 
-This replaces the old arrangement, where each target repo ran its own agent
+This replaced the old arrangement, where each target repo ran its own agent
 (`contextualize-skills.yml`) to rewrite skills on arrival. Three targets meant
-three agents and three different answers to the same question.
+three agents and three different answers to the same question. Those workflows are
+gone as of 2026-08-12; nothing rewrites skills after they leave this repo.
 
 ## Fields
 


### PR DESCRIPTION
Two lines that stopped being true when skill delivery changed.

`CLAUDE.md` said IDE-specific repos "fork from here and contextualize as needed."
They no longer do — plugin repos receive generated output and rewrite nothing. Now
states that, plus where per-target wording comes from, since that is the question
the old sentence left an author guessing about.

`targets/README.md` described the per-repo contextualize workflows in the present
tense. They were deleted on 2026-08-12.

Documentation only. No change to any skill or to the build.
