### PR TITLE
ci: add test/lint CI (runs the existing build-tool tests) + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test & lint build tools
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run build-tool tests
+        run: uv run tools/test_build.py
+
+      - name: Lint (ruff, error-level)
+        run: uvx ruff check --select E9,F63,F7,F82 tools skills targets
+
+      - name: Byte-compile Python
+        run: python -m compileall -q tools


### PR DESCRIPTION
## What

`skills` had a real test suite — `tools/test_build.py`, **54 pytest cases** guarding the cross-reference rewrite in `tools/build.py` (the transform that can silently corrupt skill content) — but **no CI ran it**. The only workflow was the dispatch-only `sync-skills` job. This adds a merge gate that runs on every PR:

1. **Runs the build-tool tests** — `uv run tools/test_build.py` (uses the PEP-723 inline pinned deps).
2. **Lints** — `ruff check --select E9,F63,F7,F82` on `tools`/`skills`/`targets`.
3. **Byte-compiles** `tools/`.

Plus a least-privilege `permissions` block and `.github/dependabot.yml` for github-actions.

## Verification (local)

- `uv run tools/test_build.py` → **54 passed** ✅
- `ruff check --select E9,F63,F7,F82` → All checks passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure-only changes (workflows and Dependabot); no application runtime or auth/data paths are modified.
> 
> **Overview**
> Adds a **CI workflow** that runs on every push to `main` and on pull requests, so the existing `tools/test_build.py` suite and build tooling checks are enforced before merge.
> 
> The job sets **read-only `contents` permissions**, uses **concurrency** to cancel superseded runs, installs Python **3.12** via `setup-uv`, then runs **`uv run tools/test_build.py`**, **`ruff check`** with error-level rules on `tools`/`skills`/`targets`, and **`compileall`** on `tools`.
> 
> Also adds **Dependabot** for `github-actions` on a weekly schedule with a cap of five open PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcf3f00b0f92534eff684d1602ab2663751cb7ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->