### PR TITLE
fix: install Pinecone CLI as a Homebrew cask (formula disabled 2026-03-30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Using Claude Code? Try our [official plugin](https://github.com/pinecone-io/pine
 - **Pinecone account** — free at [app.pinecone.io](https://app.pinecone.io/?sessionType=signup)
 - **API key** — create one in the console, then `export PINECONE_API_KEY="your-key"`
 - **Pinecone MCP** *(optional)* — enables the `query` skill and agent-native index operations. [Setup guide](https://docs.pinecone.io/guides/operations/mcp-server#tools)
-- **Pinecone CLI** *(optional)* — enables the `cli` skill. `brew install pinecone-io/tap/pinecone`
+- **Pinecone CLI** *(optional)* — enables the `cli` skill. `brew install --cask pinecone-io/tap/pinecone`
 - **uv** *(optional)* — runs the bundled Python scripts. [Install uv](https://docs.astral.sh/uv/getting-started/installation/)
 
 ---

--- a/skills/pinecone-cli/SKILL.md
+++ b/skills/pinecone-cli/SKILL.md
@@ -23,9 +23,14 @@ Manage Pinecone from the terminal. The CLI is especially valuable for vector ope
 ## Setup
 
 ### Install (macOS)
+> **Upgrading from an older install?** The Pinecone CLI moved from a Homebrew formula to a cask on 2026-03-30. If you installed it before then, remove the old formula first:
+>
+> ```bash
+> brew uninstall pinecone-io/tap/pinecone
+> ```
+
 ```bash
-brew tap pinecone-io/tap
-brew install pinecone-io/tap/pinecone
+brew install --cask pinecone-io/tap/pinecone
 ```
 
 Other platforms (Linux, Windows) — download from [GitHub Releases](https://github.com/pinecone-io/cli/releases).

--- a/skills/pinecone-help/SKILL.md
+++ b/skills/pinecone-help/SKILL.md
@@ -26,7 +26,7 @@ Here's everything you need to get started and a summary of all available skills.
 | Tool | What it enables | Install |
 |---|---|---|
 | **Pinecone MCP server** | Use Pinecone directly inside your AI agent/IDE without writing code | [Setup guide](https://docs.pinecone.io/guides/operations/mcp-server#tools) |
-| **Pinecone CLI (`pc`)** | Manage all index types from the terminal, batch operations, backups, CI/CD | `brew tap pinecone-io/tap && brew install pinecone-io/tap/pinecone` |
+| **Pinecone CLI (`pc`)** | Manage all index types from the terminal, batch operations, backups, CI/CD | `brew install --cask pinecone-io/tap/pinecone` |
 | **uv** | Run the packaged Python scripts included in these skills | [Install uv](https://docs.astral.sh/uv/getting-started/installation/) |
 
 ---

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -78,7 +78,7 @@ class TestCrossReferencesLeftAlone:
         "pinecone-clients",
         # unrelated
         "pinecone_skills:assistant",
-        "brew install pinecone-io/tap/pinecone",
+        "brew install --cask pinecone-io/tap/pinecone",
     ])
     def test_untouched(self, text):
         assert xref(text) == text


### PR DESCRIPTION
## Problem

The CLI install instructions no longer work. The `pinecone-io/tap/pinecone` **formula** was disabled on 2026-03-30 when the CLI migrated to a **cask**, so following the docs today produces:

```text
Error: pinecone-io/tap/pinecone has been disabled because it has migrated to a
cask. Reinstall with: brew uninstall pinecone-io/tap/pinecone && brew install
--cask pinecone-io/tap/pinecone! It was disabled on 2026-03-30.
```

Verified against the tap: `Formula/pinecone.rb` carries `disable! date: "2026-03-30"` pointing at the cask, and `Casks/pinecone.rb` is the live GoReleaser-generated cask (currently 1.0.1). [pinecone-io/cli's README](https://github.com/pinecone-io/cli#installation) already documents the cask form.

## Fix

Switch every install instruction to a single fully qualified command:

```bash
brew install --cask pinecone-io/tap/pinecone
```

| File | Change |
|---|---|
| `skills/pinecone-cli/SKILL.md` | single `--cask` command + upgrade note |
| `skills/pinecone-help/SKILL.md` | one-liner in the tools table |
| `README.md` | one-liner in the prerequisites list |
| `tools/test_build.py` | fixture string in `TestCrossReferencesLeftAlone` kept in step with the docs |

The upgrade note tells anyone who installed before the migration to run `brew uninstall pinecone-io/tap/pinecone` first, since Homebrew refuses to install the cask over the disabled formula.

### Why drop the separate `brew tap` step

- `brew install` taps automatically for a fully qualified `user/repo/name` (`cmd/install.rb` calls `tap.ensure_installed!` on each named argument).
- Since Homebrew 6.0.0, non-official taps require explicit trust. Installing a fully qualified cask trusts **only that cask**; the tap-then-short-name form now additionally needs `brew trust`. Homebrew's [Tap Trust docs](https://docs.brew.sh/Tap-Trust#installing-from-a-tap) give `brew install --cask user/repository/cask` as the canonical form.
- Matches peer vendor taps (HashiCorp `brew install hashicorp/tap/terraform`, Supabase `brew install supabase/tap/supabase`).

## Verification

- Clean-state run on Homebrew 6.0.22, starting with the tap untapped, no trust entries, and no cask installed. `brew install --cask pinecone-io/tap/pinecone` alone tapped `pinecone-io/tap`, printed `Trusted cask pinecone-io/tap/pinecone` (item-level trust, not whole-tap), installed cask 1.0.1, and `pc version` prints 1.0.1. Exit 0. Note the tap still ships the disabled formula alongside the cask (`Tapped 1 cask and 1 formula`), which is why the old command produced the confusing "Treating ... as a formula" warning before failing.
- `uv run tools/test_build.py`: 54 passed.
- `uv run tools/build.py --target claude-code`: "all checks passed". The rendered `cli` and `help` skills are byte-identical to the hand-applied versions in pinecone-io/pinecone-claude-code-plugin#46, so the next sync reproduces that PR's skill changes exactly.

## Related

- Sync targets: pinecone-io/pinecone-claude-code-plugin#46 fixes the plugin's README and session-start hook, which are not sync-managed, and carries the rendered form of this PR's skill edits. pinecone-io/pinecone-cursor-plugin#24 fixes that plugin's README; its skill files are fixed by the next sync from this PR.
- Not sync targets, so fixed by hand: pinecone-io/gemini-cli-extension#22 and pinecone-io/pinecone-codex-plugin#3 carry hand-copied versions of the `cli` and `help` skills.

Heads-up for reviewers: `CLAUDE.md` in this repo lists `tools/check-skills.py`, `check-source-tags.py`, and `check-links.py` as the lint step, but none exist in `tools/`. Left alone here as out of scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test fixture updates only; no application or install script logic changes.
> 
> **Overview**
> **Updates Pinecone CLI install docs** after the Homebrew **formula was disabled (2026-03-30)** in favor of a **cask**. Every mention now uses **`brew install --cask pinecone-io/tap/pinecone`** instead of **`brew tap`** plus a formula install.
> 
> The **`pinecone-cli`** skill adds a short **upgrade note**: uninstall the old formula with **`brew uninstall pinecone-io/tap/pinecone`** before installing the cask. **`README.md`**, **`pinecone-help`**, and the **`test_build.py`** cross-reference fixture are aligned with the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5f20139980710fa1b5af311a30ab7c8aed8823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

