### PR TITLE
feat: add gemini-cli and codex as sync targets

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -16,6 +16,8 @@ on:
           - all
           - pinecone-io/pinecone-claude-code-plugin
           - pinecone-io/pinecone-cursor-plugin
+          - pinecone-io/gemini-cli-extension
+          - pinecone-io/pinecone-codex-plugin
         default: all
       dry_run:
         description: 'Build, reconcile, and print the plan without opening a PR'
@@ -48,6 +50,12 @@ jobs:
             skills_path: skills
           - name: cursor
             repo: pinecone-io/pinecone-cursor-plugin
+            skills_path: skills
+          - name: gemini-cli
+            repo: pinecone-io/gemini-cli-extension
+            skills_path: skills
+          - name: codex
+            repo: pinecone-io/pinecone-codex-plugin
             skills_path: skills
 
     name: Sync → ${{ matrix.target.repo }}
@@ -140,8 +148,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
 
-      # --delete verified safe for these two targets only. Re-run reconcile.py before
-      # adding a third.
+      # --delete reconciled against all four targets before each was added. Re-run
+      # reconcile.py before adding another; EXTRA files are deletions.
       - name: Sync rendered tree into target
         if: steps.gate.outputs.skip == 'false'
         env:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -3,8 +3,11 @@ name: Sync Skills to Plugin Repos
 # Renders skills/ through tools/build.py and rsyncs the result into each plugin
 # repo, opening one PR per target. Dispatch-only.
 #
-# Branch has NO suffix: contextualize-skills.yml in both plugin repos gates on
-# `sync/skills-` (trailing hyphen), so this name deliberately does not match.
+# Branch has NO suffix: the retired contextualize workflows still present in
+# some target repos (contextualize-skills.yml in claude-code and codex,
+# contextualize.yml in gemini-cli) gate on `sync/skills-` (trailing hyphen), so
+# this name deliberately does not match. Delete those workflows as each target
+# is cut over.
 
 on:
   workflow_dispatch:
@@ -45,18 +48,27 @@ jobs:
           # `name` is the manifest stem in targets/. `skills_path` must match the
           # manifest's own skills_path — the guard step below fails loudly if it
           # drifts, rather than syncing into the wrong directory.
+          # `enabled` gates the `all` dispatch. A target that is not yet enabled
+          # only runs when selected by name, so a routine "all" cannot open a
+          # migration PR into a repo nobody has decided to cut over, and cannot go
+          # red on a repo PLUGIN_SYNC_PAT cannot write to yet. Flip to true once
+          # the PAT covers the repo and the first sync has been reviewed.
           - name: claude-code
             repo: pinecone-io/pinecone-claude-code-plugin
             skills_path: skills
+            enabled: true
           - name: cursor
             repo: pinecone-io/pinecone-cursor-plugin
             skills_path: skills
+            enabled: true
           - name: gemini-cli
             repo: pinecone-io/gemini-cli-extension
             skills_path: skills
+            enabled: false
           - name: codex
             repo: pinecone-io/pinecone-codex-plugin
             skills_path: skills
+            enabled: false
 
     name: Sync → ${{ matrix.target.repo }}
 
@@ -66,9 +78,15 @@ jobs:
         env:
           SELECTED: ${{ inputs.target_repo }}
           THIS_REPO: ${{ matrix.target.repo }}
+          ENABLED: ${{ matrix.target.enabled }}
         run: |
-          if [[ "$SELECTED" == "all" || "$SELECTED" == "$THIS_REPO" ]]; then
+          if [[ "$SELECTED" == "$THIS_REPO" ]]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$SELECTED" == "all" && "$ENABLED" == "true" ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$SELECTED" == "all" ]]; then
+            echo "Skipping $THIS_REPO: not enabled for 'all'; select it by name to sync it"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "Skipping $THIS_REPO (selected: $SELECTED)"
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/skills/pinecone-help/SKILL.md
+++ b/skills/pinecone-help/SKILL.md
@@ -25,7 +25,7 @@ Here's everything you need to get started and a summary of all available skills.
 
 | Tool | What it enables | Install |
 |---|---|---|
-| **Pinecone MCP server** | Use Pinecone directly inside your AI agent/IDE without writing code | [Setup guide](https://docs.pinecone.io/guides/operations/mcp-server#tools) |
+| **Pinecone MCP server** | Use Pinecone directly inside your AI agent/IDE without writing code | <<mcp_server_status>> |
 | **Pinecone CLI (`pc`)** | Manage all index types from the terminal, batch operations, backups, CI/CD | `brew tap pinecone-io/tap && brew install pinecone-io/tap/pinecone` |
 | **uv** | Run the packaged Python scripts included in these skills | [Install uv](https://docs.astral.sh/uv/getting-started/installation/) |
 
@@ -40,9 +40,9 @@ Here's everything you need to get started and a summary of all available skills.
 | `pinecone-cli` | Use the Pinecone CLI (`pc`) for terminal-based index and vector management |
 | `pinecone-assistant` | Create, manage, and chat with Pinecone Assistants for document Q&A with citations |
 | `pinecone-mcp` | Reference for all Pinecone MCP server tools and their parameters |
-| `pinecone-full-text-search` | Build a full-text-search index — schema design, safe bulk ingestion, and query construction (`text` / `query_string` / dense / sparse scoring with text-match and metadata filters). **Document-schema API (`2026-07`); requires `pinecone` Python SDK ≥ 10.0.0.** |
+<<help_row_full_text_search>>
 | `pinecone-docs` | Curated links to official Pinecone documentation, organized by topic |
-| `pinecone-n8n` | Build n8n workflows with the Pinecone Assistant node or Pinecone Vector Store node, including best practices and full workflow JSON generation |
+<<help_row_n8n>>
 
 ---
 
@@ -56,9 +56,9 @@ Here's everything you need to get started and a summary of all available skills.
 
 **Working with documents and Q&A?** → `pinecone-assistant`
 
-**Building a full-text search index (BM25-style keyword/phrase matching, optionally combined with dense or sparse vectors)?** → `pinecone-full-text-search` (document-schema API, needs `pinecone` Python SDK ≥ 10.0.0)
+<<help_route_full_text_search>>
 
-**Building an n8n workflow with Pinecone (RAG pipeline, chat with docs)?** → `pinecone-n8n`
+<<help_route_n8n>>
 
 **Need to manage indexes, bulk upload vectors, or automate workflows?** → `pinecone-cli`
 

--- a/targets/README.md
+++ b/targets/README.md
@@ -31,7 +31,7 @@ Base uses exactly four keys, and the build must emit them in this order:
 ```
 name:            # rewritten per skill_name
 description:     # passed through unchanged
-argument-hint:   # passed through unchanged; only cli and query have one
+argument-hint:   # passed through unless the manifest lists it in drop_frontmatter; only cli and query have one
 allowed-tools:   # added from the manifest; base has none
 ```
 
@@ -116,6 +116,11 @@ snippets:
   text passes through the same guards as base content — write `pinecone-cli` in a
   snippet and it retargets correctly.
 - Trailing newlines are stripped, so `|` block scalars sit cleanly inline.
+- An empty snippet (`""`) on a line that holds nothing but the marker removes
+  the whole line, and one adjacent blank line with it. This is how a target drops
+  a table row or a routing bullet for a skill it does not ship.
+- A key may not appear in both `frontmatter` (added per slug) and
+  `drop_frontmatter`; the build refuses rather than let one rule silently win.
 
 ### Writing snippets that land inside Python
 
@@ -155,7 +160,11 @@ legitimately *ahead* of base: `create.py` in the Claude plugin was, for months.
    exact regression test. It replaces paid evals for that target.
 2. **Idempotence.** Building twice produces identical bytes.
 3. **Round-trip on names.** Every rendered `name:` matches the target's live
-   value for all nine skills.
+   value for every included skill. The one deliberate exception is gemini-cli's
+   `docs`, recorded under "Known deltas".
+4. **No reference to a skill the target does not ship.** `check_excluded_references`
+   fails on any `pinecone-<slug>` for a slug outside `include`, in every rendered
+   `.md` and `.py`.
 
 ## Known deltas
 
@@ -196,6 +205,14 @@ first sync is a migration. Reconciled against live `main` on 2026-09-09:
   and `description`. `drop_frontmatter` strips it from cli and query.
 - **gemini-cli carries one `.gitkeep`** that `rsync --delete` removes. Same shape as
   cursor's.
+- **The help skill lists all nine base skills.** gemini-cli and codex fill the
+  row and routing markers for skills they do not ship with `""`, which removes
+  those lines; the excluded-reference check fails the build if a reference to an
+  unshipped skill survives anywhere else.
+- **gemini-cli's live help said the MCP server was already installed** by the
+  extension, where base linked a setup guide. `<<mcp_server_status>>` carries the
+  per-target wording; the other three targets keep the link, so nothing changes
+  for them.
 - Both repos still contain the retired `contextualize` workflow, gated on
   `sync/skills-`. It never fires against `sync/skills` and should be deleted as it
   was for the other two targets.

--- a/targets/README.md
+++ b/targets/README.md
@@ -22,6 +22,7 @@ gone as of 2026-08-12; nothing rewrites skills after they leave this repo.
 | `snippets` | Wording for the `<<name>>` markers in base. See "Snippets" below. |
 | `include` | Slugs to render. Explicit, so adding a skill to base does not silently publish it everywhere. |
 | `frontmatter` | Per-slug keys this target adds. Emitted after `argument-hint`. |
+| `drop_frontmatter` | Optional. Keys stripped from every rendered `SKILL.md`. Only `argument-hint` and `allowed-tools` may be listed; `name` and `description` are required by the Agent Skills spec. |
 
 ## Frontmatter contract
 
@@ -175,3 +176,26 @@ is reconciliation work, not build work.
   `rsync --delete` will remove them. They are vestigial — every directory holding
   one also holds real files — but it is a deletion, so it should be a deliberate
   call rather than a surprise in the first sync PR.
+
+### gemini-cli and codex, added 2026-09
+
+Both targets were hand-copied from the Claude plugin and never synced, so their
+first sync is a migration. Reconciled against live `main` on 2026-09-09:
+
+- **Both ship the SDK 8 assistant scripts** that claude-code-plugin#37 replaced in
+  June. `pinecone>=8.0.0` now resolves to 10.0.0 and `chat.py` fails at import.
+  The sync overwrites all six scripts.
+- **Both advertise `/pinecone:assistant-*` slash commands** in script output. Neither
+  product has them. The `next_*` snippets name the scripts instead, as cursor does.
+- **codex's `full-text-search` targets `pinecone.preview`** and pins 9.0.0; base
+  moved to 10.0.0 on 2026-09-03. About 600 lines change.
+- **codex stamped `agentic-ide-source: claude-code-plugin`.** Fixed by `ide_source`.
+- **gemini-cli keeps `pinecone-docs/` on disk.** `dir_name` is one template, so the
+  render produces `docs/`. `GEMINI.md`'s skill table needs the matching rename.
+- **gemini-cli carries `argument-hint` nowhere**, and Gemini documents only `name`
+  and `description`. `drop_frontmatter` strips it from cli and query.
+- **gemini-cli carries one `.gitkeep`** that `rsync --delete` removes. Same shape as
+  cursor's.
+- Both repos still contain the retired `contextualize` workflow, gated on
+  `sync/skills-`. It never fires against `sync/skills` and should be deleted as it
+  was for the other two targets.

--- a/targets/claude-code.yaml
+++ b/targets/claude-code.yaml
@@ -111,3 +111,17 @@ snippets:
     Invoke any skill from chat with `/pinecone:<skill-name>` — for example
     `/pinecone:quickstart` or `/pinecone:n8n`.
   invoke_this_skill: "Invoke this skill from chat with `/pinecone:n8n`."
+
+  # The help skill lists every base skill. A target that does not ship one fills
+  # its row and routing line with an empty string, which removes the line.
+  help_row_full_text_search: |
+    | `pinecone-full-text-search` | Build a full-text-search index — schema design, safe bulk ingestion, and query construction (`text` / `query_string` / dense / sparse scoring with text-match and metadata filters). **Document-schema API (`2026-07`); requires `pinecone` Python SDK ≥ 10.0.0.** |
+  help_route_full_text_search: |
+    **Building a full-text search index (BM25-style keyword/phrase matching, optionally combined with dense or sparse vectors)?** → `pinecone-full-text-search` (document-schema API, needs `pinecone` Python SDK ≥ 10.0.0)
+  help_row_n8n: |
+    | `pinecone-n8n` | Build n8n workflows with the Pinecone Assistant node or Pinecone Vector Store node, including best practices and full workflow JSON generation |
+  help_route_n8n: |
+    **Building an n8n workflow with Pinecone (RAG pipeline, chat with docs)?** → `pinecone-n8n`
+
+  # Third column of the help table's MCP row.
+  mcp_server_status: "[Setup guide](https://docs.pinecone.io/guides/operations/mcp-server#tools)"

--- a/targets/codex.yaml
+++ b/targets/codex.yaml
@@ -79,8 +79,23 @@ snippets:
     destructive step, or pick from a list, ask in plain prose, list the options,
     and wait for their answer before continuing.
 
-  # From the live README: skills are invoked by name with `$<skill>` or via
-  # `@pinecone`.
+  # Codex exposes a plugin's skills as `<plugin>:<skill>` and matches names exactly,
+  # so the invocable name is `pinecone:cli`, not `cli`. The live README's `$<skill>`
+  # wording is wrong on this point; the live help table already used the
+  # namespaced form, and this snippet now agrees with it.
   invoke_any_skill: >
-    Invoke any skill from Codex with `$<skill-name>` — for example `$quickstart` or
-    `$cli` — or mention `@pinecone` and describe what you want.
+    Invoke any skill from Codex with `$pinecone:<skill-name>` — for example
+    `$pinecone:quickstart` or `$pinecone:cli` — or mention `@pinecone` and describe
+    what you want.
+
+  # The help skill lists every base skill. A target that does not ship one fills
+  # its row and routing line with an empty string, which removes the line.
+  help_row_full_text_search: |
+    | `pinecone-full-text-search` | Build a full-text-search index — schema design, safe bulk ingestion, and query construction (`text` / `query_string` / dense / sparse scoring with text-match and metadata filters). **Document-schema API (`2026-07`); requires `pinecone` Python SDK ≥ 10.0.0.** |
+  help_route_full_text_search: |
+    **Building a full-text search index (BM25-style keyword/phrase matching, optionally combined with dense or sparse vectors)?** → `pinecone-full-text-search` (document-schema API, needs `pinecone` Python SDK ≥ 10.0.0)
+  help_row_n8n: ""
+  help_route_n8n: ""
+
+  # Third column of the help table's MCP row.
+  mcp_server_status: "[Setup guide](https://docs.pinecone.io/guides/operations/mcp-server#tools)"

--- a/targets/codex.yaml
+++ b/targets/codex.yaml
@@ -1,0 +1,86 @@
+# Build manifest — Codex plugin
+#
+# Consumed by tools/build.py, which renders skills/ -> dist/codex/.
+# Derived from the observed state of the live target repo on 2026-09-09. Until
+# this manifest existed the plugin carried hand-copied skills and received no
+# fixes from base; see the "Known deltas" section of targets/README.md.
+
+repo: pinecone-io/pinecone-codex-plugin
+skills_path: skills
+
+# The plugin manifest namespaces skills under `pinecone`, so bare slugs on disk
+# and in `name:`, matching the live repo.
+dir_name: "{slug}"
+skill_name: "{slug}"
+
+# The live repo's (retired) contextualize prompt mandated `pinecone:<skill>` in
+# prose, and that is what the live files use. Its README tells users to invoke
+# skills as `$<skill>`. Kept the prose form to match live content; switching is a
+# one-line change here if maintainers prefer the README form.
+cross_reference: "pinecone:{slug}"
+
+source_tag: codex_plugin
+
+# The live repo stamped `claude-code-plugin` here, copied from the Claude plugin,
+# so assistants created from Codex were attributed to Claude Code.
+ide_source: codex-plugin
+
+# Eight of nine. The live plugin never shipped n8n.
+include:
+  - assistant
+  - cli
+  - docs
+  - full-text-search
+  - help
+  - mcp
+  - query
+  - quickstart
+
+# Codex skills carry no allowed-tools; argument-hint is passed through, matching
+# the live cli and query skills.
+frontmatter: {}
+
+# Per-target wording for the `<<name>>` markers in base. See targets/README.md.
+#
+# Codex reads the shell for both the MCP server and the scripts. It declares no
+# slash commands; the live scripts advertised `/pinecone:assistant-*` commands
+# that never existed here, so the next-step snippets name the scripts to run.
+snippets:
+  api_key_setup: |
+    - Run `export PINECONE_API_KEY="your-key"` in your terminal. Codex reads your
+      shell environment for both the MCP server and the bundled scripts.
+
+  next_after_create: |
+    1. Upload files: [cyan]uv run upload.py --assistant {name} --source PATH[/cyan]
+    2. Chat: [cyan]uv run chat.py --assistant {name} --message "YOUR QUESTION"[/cyan]
+    3. Get context: [cyan]uv run context.py --assistant {name} --query "SEARCH TEXT"[/cyan]
+
+  next_create_first: "[cyan]uv run create.py --name ASSISTANT_NAME[/cyan]"
+
+  next_commands: |
+    • List with files: [cyan]uv run list.py --files[/cyan]
+    • Chat: [cyan]uv run chat.py --assistant NAME --message "YOUR QUESTION"[/cyan]
+    • Upload: [cyan]uv run upload.py --assistant NAME --source PATH[/cyan]
+    • Context: [cyan]uv run context.py --assistant NAME --query "SEARCH TEXT"[/cyan]
+
+  next_after_upload: |
+    • Chat: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
+    • Context: [cyan]uv run context.py --assistant {assistant} --query "SEARCH TEXT"[/cyan]
+
+  next_after_context: |
+    • Ask a question: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
+    • Upload more files: [cyan]uv run upload.py --assistant {assistant} --source PATH[/cyan]
+
+  next_chat_fallback: 'uv run chat.py --assistant {assistant} --message \"{query}\"'
+
+  # No structured-choice tool here, so say what to do instead.
+  clarify_style: >
+    Whenever this skill asks the user to choose between options, confirm a
+    destructive step, or pick from a list, ask in plain prose, list the options,
+    and wait for their answer before continuing.
+
+  # From the live README: skills are invoked by name with `$<skill>` or via
+  # `@pinecone`.
+  invoke_any_skill: >
+    Invoke any skill from Codex with `$<skill-name>` — for example `$quickstart` or
+    `$cli` — or mention `@pinecone` and describe what you want.

--- a/targets/cursor.yaml
+++ b/targets/cursor.yaml
@@ -92,3 +92,17 @@ snippets:
     Invoke any skill from Cursor Agent chat with `/pinecone-<skill-name>` — for
     example `/pinecone-quickstart` or `/pinecone-n8n`.
   invoke_this_skill: "Invoke this skill from Cursor Agent chat with `/pinecone-n8n`."
+
+  # The help skill lists every base skill. A target that does not ship one fills
+  # its row and routing line with an empty string, which removes the line.
+  help_row_full_text_search: |
+    | `pinecone-full-text-search` | Build a full-text-search index — schema design, safe bulk ingestion, and query construction (`text` / `query_string` / dense / sparse scoring with text-match and metadata filters). **Document-schema API (`2026-07`); requires `pinecone` Python SDK ≥ 10.0.0.** |
+  help_route_full_text_search: |
+    **Building a full-text search index (BM25-style keyword/phrase matching, optionally combined with dense or sparse vectors)?** → `pinecone-full-text-search` (document-schema API, needs `pinecone` Python SDK ≥ 10.0.0)
+  help_row_n8n: |
+    | `pinecone-n8n` | Build n8n workflows with the Pinecone Assistant node or Pinecone Vector Store node, including best practices and full workflow JSON generation |
+  help_route_n8n: |
+    **Building an n8n workflow with Pinecone (RAG pipeline, chat with docs)?** → `pinecone-n8n`
+
+  # Third column of the help table's MCP row.
+  mcp_server_status: "[Setup guide](https://docs.pinecone.io/guides/operations/mcp-server#tools)"

--- a/targets/gemini-cli.yaml
+++ b/targets/gemini-cli.yaml
@@ -1,0 +1,85 @@
+# Build manifest — Gemini CLI extension
+#
+# Consumed by tools/build.py, which renders skills/ -> dist/gemini-cli/.
+# Derived from the observed state of the live target repo on 2026-09-09. Until
+# this manifest existed the extension carried hand-copied skills and received no
+# fixes from base; see the "Known deltas" section of targets/README.md.
+
+repo: pinecone-io/gemini-cli-extension
+skills_path: skills
+
+# The extension namespaces skills itself, so the prefix is redundant on disk and
+# in `name:`. The live repo kept `pinecone-docs/` as a one-off because `docs`
+# alone read as generic; base cannot express a per-slug exception, and `name:`
+# is what Gemini routes on, so this manifest renders it as `docs/` like the
+# Claude Code and Codex targets do. GEMINI.md's skill table needs the same rename.
+dir_name: "{slug}"
+skill_name: "{slug}"
+cross_reference: "{slug}"
+
+source_tag: gemini_cli
+ide_source: gemini-cli
+
+# Seven of nine. The live extension never shipped n8n or full-text-search.
+include:
+  - assistant
+  - cli
+  - docs
+  - help
+  - mcp
+  - query
+  - quickstart
+
+# Gemini CLI documents exactly two frontmatter keys, name and description, and
+# says nothing about how unknown keys are treated. Base carries argument-hint on
+# cli and query; strip it rather than rely on undocumented tolerance.
+frontmatter: {}
+drop_frontmatter:
+  - argument-hint
+
+# Per-target wording for the `<<name>>` markers in base. See targets/README.md.
+#
+# The extension declares PINECONE_API_KEY as a setting for its MCP server, but the
+# bundled scripts read the shell, so users need both. Gemini CLI declares no slash
+# commands; the live scripts advertised `/pinecone:assistant-*` commands that never
+# existed here, so the next-step snippets name the scripts you can actually run.
+snippets:
+  api_key_setup: |
+    - Set it in your Gemini CLI settings for the Pinecone MCP server (the extension
+      declares it as a setting), and also run `export PINECONE_API_KEY="your-key"` in
+      your terminal so the bundled scripts can read it.
+
+  next_after_create: |
+    1. Upload files: [cyan]uv run upload.py --assistant {name} --source PATH[/cyan]
+    2. Chat: [cyan]uv run chat.py --assistant {name} --message "YOUR QUESTION"[/cyan]
+    3. Get context: [cyan]uv run context.py --assistant {name} --query "SEARCH TEXT"[/cyan]
+
+  next_create_first: "[cyan]uv run create.py --name ASSISTANT_NAME[/cyan]"
+
+  next_commands: |
+    • List with files: [cyan]uv run list.py --files[/cyan]
+    • Chat: [cyan]uv run chat.py --assistant NAME --message "YOUR QUESTION"[/cyan]
+    • Upload: [cyan]uv run upload.py --assistant NAME --source PATH[/cyan]
+    • Context: [cyan]uv run context.py --assistant NAME --query "SEARCH TEXT"[/cyan]
+
+  next_after_upload: |
+    • Chat: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
+    • Context: [cyan]uv run context.py --assistant {assistant} --query "SEARCH TEXT"[/cyan]
+
+  next_after_context: |
+    • Ask a question: [cyan]uv run chat.py --assistant {assistant} --message "YOUR QUESTION"[/cyan]
+    • Upload more files: [cyan]uv run upload.py --assistant {assistant} --source PATH[/cyan]
+
+  next_chat_fallback: 'uv run chat.py --assistant {assistant} --message \"{query}\"'
+
+  # No structured-choice tool here, so say what to do instead.
+  clarify_style: >
+    Whenever this skill asks the user to choose between options, confirm a
+    destructive step, or pick from a list, ask in plain prose, list the options,
+    and wait for their answer before continuing.
+
+  # Gemini CLI routes to skills from intent and has no slash form. The live help
+  # skill already said this.
+  invoke_any_skill: >
+    Gemini CLI activates skills from your intent. If routing misses, ask for one by
+    name, for example "Use the quickstart skill".

--- a/targets/gemini-cli.yaml
+++ b/targets/gemini-cli.yaml
@@ -45,9 +45,11 @@ drop_frontmatter:
 # existed here, so the next-step snippets name the scripts you can actually run.
 snippets:
   api_key_setup: |
-    - Set it in your Gemini CLI settings for the Pinecone MCP server (the extension
-      declares it as a setting), and also run `export PINECONE_API_KEY="your-key"` in
-      your terminal so the bundled scripts can read it.
+    - Run `gemini extensions config pinecone` and set the Pinecone API Key. The
+      extension passes only its declared settings to the bundled MCP server; it does
+      not inherit your shell environment.
+    - Also run `export PINECONE_API_KEY="your-key"` in your terminal so the bundled
+      scripts, which do run in your shell, can read it.
 
   next_after_create: |
     1. Upload files: [cyan]uv run upload.py --assistant {name} --source PATH[/cyan]
@@ -83,3 +85,13 @@ snippets:
   invoke_any_skill: >
     Gemini CLI activates skills from your intent. If routing misses, ask for one by
     name, for example "Use the quickstart skill".
+
+  # The help skill lists every base skill. A target that does not ship one fills
+  # its row and routing line with an empty string, which removes the line.
+  help_row_full_text_search: ""
+  help_route_full_text_search: ""
+  help_row_n8n: ""
+  help_route_n8n: ""
+
+  # Third column of the help table's MCP row.
+  mcp_server_status: "Already installed for you in Gemini CLI!"

--- a/tools/build.py
+++ b/tools/build.py
@@ -79,6 +79,15 @@ def load_manifest(target: str) -> dict[str, Any]:
     unknown = set(m["frontmatter"]) - set(m["include"])
     if unknown:
         raise ValueError(f"{target}.yaml has frontmatter for non-included slugs: {sorted(unknown)}")
+    # Keys a target strips from every rendered SKILL.md. `name` and `description`
+    # are required by the Agent Skills spec and cannot be dropped.
+    drop = m.get("drop_frontmatter") or []
+    if not isinstance(drop, list):
+        raise ValueError(f"{target}.yaml: drop_frontmatter must be a list")
+    bad = [k for k in drop if k not in FRONTMATTER_ORDER or k in ("name", "description")]
+    if bad:
+        raise ValueError(f"{target}.yaml: drop_frontmatter cannot drop {bad}")
+    m["drop_frontmatter"] = drop
     return m
 
 
@@ -246,6 +255,8 @@ def render_skill_md(text: str, slug: str, manifest: dict[str, Any], path: Path) 
     extra = (manifest["frontmatter"].get(slug) or {})
     for key, value in extra.items():
         fm[key] = value
+    for key in manifest.get("drop_frontmatter") or []:
+        fm.pop(key, None)
 
     # Cross-references appear in the description as well as the body.
     if "description" in fm:

--- a/tools/build.py
+++ b/tools/build.py
@@ -66,16 +66,14 @@ FRONTMATTER_ORDER = ["name", "description", "argument-hint", "allowed-tools"]
 # manifest
 # --------------------------------------------------------------------------- #
 
-def load_manifest(target: str) -> dict[str, Any]:
-    path = TARGETS_DIR / f"{target}.yaml"
-    if not path.exists():
-        raise typer.BadParameter(f"no manifest at {path.relative_to(REPO)}")
-    m = yaml.safe_load(path.read_text())
+def validate_manifest(m: dict[str, Any], target: str) -> dict[str, Any]:
+    """Normalise and validate a loaded manifest. Pure, so it is testable without
+    a file on disk. Returns the same dict, mutated in place."""
     for key in ("repo", "skills_path", "dir_name", "skill_name", "cross_reference",
                 "source_tag", "ide_source", "include"):
         if key not in m:
             raise ValueError(f"{target}.yaml is missing required key: {key}")
-    m.setdefault("frontmatter", {}) or m.__setitem__("frontmatter", m.get("frontmatter") or {})
+    m["frontmatter"] = m.get("frontmatter") or {}
     unknown = set(m["frontmatter"]) - set(m["include"])
     if unknown:
         raise ValueError(f"{target}.yaml has frontmatter for non-included slugs: {sorted(unknown)}")
@@ -87,8 +85,27 @@ def load_manifest(target: str) -> dict[str, Any]:
     bad = [k for k in drop if k not in FRONTMATTER_ORDER or k in ("name", "description")]
     if bad:
         raise ValueError(f"{target}.yaml: drop_frontmatter cannot drop {bad}")
+    # Adding a key per slug and dropping it globally would discard both values
+    # without a trace. Refuse rather than let the last rule silently win.
+    added = {k for per_slug in m["frontmatter"].values() for k in (per_slug or {})}
+    clash = sorted(added & set(drop))
+    if clash:
+        raise ValueError(f"{target}.yaml: {clash} appear in both frontmatter and drop_frontmatter")
     m["drop_frontmatter"] = drop
     return m
+
+
+def load_manifest(target: str) -> dict[str, Any]:
+    path = TARGETS_DIR / f"{target}.yaml"
+    if not path.exists():
+        raise typer.BadParameter(f"no manifest at {path.relative_to(REPO)}")
+    return validate_manifest(yaml.safe_load(path.read_text()), target)
+
+
+def base_slugs() -> list[str]:
+    """Every skill in base, by slug. The universe `include` selects from."""
+    return sorted(p.name[len(BASE_PREFIX):] for p in SKILLS_DIR.iterdir()
+                  if p.is_dir() and p.name.startswith(BASE_PREFIX))
 
 
 def available_targets() -> list[str]:
@@ -202,16 +219,33 @@ def fill_snippets(text: str, manifest: dict[str, Any], path: Path) -> str:
     """
     snippets = manifest.get("snippets") or {}
 
-    def repl(match: re.Match[str]) -> str:
-        name = match.group(1)
+    def value(name: str) -> str:
         if name not in snippets:
             raise ValueError(
                 f"{path}: no snippet {name!r} for this target. Define it in "
                 f"targets/*.yaml for every target, or remove the marker from base."
             )
-        return str(snippets[name]).strip()
+        return str(snippets[name] or "").strip()
 
-    return SNIPPET_RE.sub(repl, text)
+    # A marker that is the only thing on its line, filled with an empty snippet,
+    # takes the whole line with it. That is how a target omits a table row or a
+    # routing bullet for a skill it does not ship, without leaving a blank cell or
+    # a broken table behind. One trailing blank line is absorbed so a removed
+    # paragraph does not leave a double gap.
+    out: list[str] = []
+    lines = text.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        whole = SNIPPET_RE.fullmatch(line.strip())
+        if whole and value(whole.group(1)) == "":
+            if out and out[-1] == "" and i + 1 < len(lines) and lines[i + 1] == "":
+                i += 1
+            i += 1
+            continue
+        out.append(SNIPPET_RE.sub(lambda m: value(m.group(1)), line))
+        i += 1
+    return "\n".join(out)
 
 
 def split_frontmatter(text: str, path: Path) -> tuple[dict[str, str], str]:
@@ -373,6 +407,44 @@ def check_identity_target(target: str, out_root: Path | None = None) -> list[str
     return problems
 
 
+def find_excluded_references(text: str, manifest: dict[str, Any], all_slugs: list[str]) -> list[tuple[int, str]]:
+    """(line number, slug) for every reference to a base skill this target does
+    not include. Uses the same bounded pattern as cross-reference rewriting, so a
+    URL or package name that merely contains the text is not a hit."""
+    excluded = [s for s in all_slugs if s not in manifest["include"]]
+    if not excluded:
+        return []
+    pattern = cross_reference_pattern(excluded)
+    hits: list[tuple[int, str]] = []
+    for n, line in enumerate(text.split("\n"), 1):
+        for m in pattern.finditer(line):
+            hits.append((n, m.group(0)[len(BASE_PREFIX):]))
+    return hits
+
+
+def check_excluded_references(target: str, out_root: Path | None = None) -> list[str]:
+    """Rendered content must not point at a skill the target does not ship.
+
+    The cross-reference rewrite only knows about included slugs, so a table row or
+    routing line for an excluded skill passes through in base form and tells the
+    user to invoke something that does not exist there. The help skill is the
+    obvious case; base handles it with markers filled empty per target. This check
+    is what fails when a new reference sneaks in anywhere else.
+    """
+    manifest = load_manifest(target)
+    out = (out_root or DIST_DIR) / target / manifest["skills_path"]
+    problems: list[str] = []
+    for path in sorted(out.rglob("*")):
+        if path.is_dir() or path.suffix not in (".md", ".py"):
+            continue
+        for n, slug in find_excluded_references(path.read_text(), manifest, base_slugs()):
+            problems.append(
+                f"{target}: {path.relative_to(out)}:{n} references {BASE_PREFIX}{slug}, "
+                f"which this target does not include"
+            )
+    return problems
+
+
 def check_no_neutral_tags(target: str, out_root: Path | None = None) -> list[str]:
     """No rendered output may still carry a neutral per-target marker.
 
@@ -480,6 +552,7 @@ def main(
         problems += check_no_neutral_tags(t, out_root)
         problems += check_identity_target(t, out_root)
         problems += check_snippets(t)
+        problems += check_excluded_references(t, out_root)
         problems += check_python_syntax(t, out_root)
         if check:
             import tempfile

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -271,6 +271,20 @@ class TestFrontmatter:
         with pytest.raises(ValueError, match="must open with"):
             build.render_skill_md("no frontmatter here\n", "help", CLAUDE, Path("x"))
 
+    def test_drop_frontmatter_removes_key(self):
+        """Gemini CLI documents only name and description; base carries argument-hint
+        on cli and query, so a target must be able to strip it."""
+        src = "---\nname: pinecone-cli\ndescription: D\nargument-hint: install | auth\n---\nB\n"
+        m = dict(CLAUDE, skill_name="{slug}", frontmatter={}, drop_frontmatter=["argument-hint"])
+        out = build.render_skill_md(src, "cli", m, Path("x"))
+        assert out.startswith("---\nname: cli\ndescription: D\n---\n")
+        assert "argument-hint" not in out
+
+    def test_drop_frontmatter_is_a_noop_when_key_absent(self):
+        m = dict(CLAUDE, skill_name="{slug}", frontmatter={}, drop_frontmatter=["argument-hint"])
+        out = build.render_skill_md(self.BASE, "quickstart", m, Path("x"))
+        assert out.startswith("---\nname: quickstart\ndescription: Do a thing.\n---\n")
+
 
 class TestFileDispatch:
     def test_py_gets_source_tag_only_not_cross_refs(self):

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -286,6 +286,67 @@ class TestFrontmatter:
         assert out.startswith("---\nname: quickstart\ndescription: Do a thing.\n---\n")
 
 
+class TestValidateManifest:
+    BASE = {"repo": "o/r", "skills_path": "skills", "dir_name": "{slug}", "skill_name": "{slug}",
+            "cross_reference": "{slug}", "source_tag": "t", "ide_source": "t", "include": SLUGS}
+
+    def test_drop_must_be_a_list(self):
+        with pytest.raises(ValueError, match="must be a list"):
+            build.validate_manifest(dict(self.BASE, drop_frontmatter="argument-hint"), "x")
+
+    def test_cannot_drop_required_keys(self):
+        with pytest.raises(ValueError, match="cannot drop"):
+            build.validate_manifest(dict(self.BASE, drop_frontmatter=["name"]), "x")
+
+    def test_cannot_drop_unknown_key(self):
+        with pytest.raises(ValueError, match="cannot drop"):
+            build.validate_manifest(dict(self.BASE, drop_frontmatter=["mystery"]), "x")
+
+    def test_add_and_drop_same_key_is_an_error(self):
+        """Otherwise both the base value and the manifest's are discarded silently."""
+        m = dict(self.BASE, frontmatter={"cli": {"argument-hint": "x"}}, drop_frontmatter=["argument-hint"])
+        with pytest.raises(ValueError, match="both frontmatter and drop_frontmatter"):
+            build.validate_manifest(m, "x")
+
+    def test_valid_drop_is_normalised(self):
+        m = build.validate_manifest(dict(self.BASE), "x")
+        assert m["drop_frontmatter"] == [] and m["frontmatter"] == {}
+
+
+class TestEmptySnippetRemovesLine:
+    M = {"snippets": {"row": "", "cell": "", "text": "hello"}}
+
+    def test_marker_only_line_is_removed(self):
+        src = "| a |\n<<row>>\n| b |\n"
+        assert build.fill_snippets(src, self.M, Path("x")) == "| a |\n| b |\n"
+
+    def test_removed_paragraph_takes_one_blank_with_it(self):
+        src = "para\n\n<<row>>\n\nnext\n"
+        assert build.fill_snippets(src, self.M, Path("x")) == "para\n\nnext\n"
+
+    def test_inline_empty_snippet_leaves_the_line(self):
+        assert build.fill_snippets("| x | <<cell>> |\n", self.M, Path("x")) == "| x |  |\n"
+
+    def test_non_empty_still_substitutes(self):
+        assert build.fill_snippets("say <<text>>\n", self.M, Path("x")) == "say hello\n"
+
+
+class TestExcludedReferences:
+    SEVEN = [s for s in SLUGS if s not in ("full-text-search", "n8n")]
+    M = {"include": SEVEN}
+
+    def test_reference_to_excluded_skill_is_found(self):
+        hits = build.find_excluded_references("see `pinecone-n8n` and pinecone-full-text-search\n", self.M, SLUGS)
+        assert hits == [(1, "n8n"), (1, "full-text-search")]
+
+    def test_included_and_lookalikes_are_ignored(self):
+        text = "`pinecone-cli` https://github.com/pinecone-io/skills @pinecone-database/n8n-nodes-pinecone-assistant\n"
+        assert build.find_excluded_references(text, self.M, SLUGS) == []
+
+    def test_nothing_excluded_means_nothing_found(self):
+        assert build.find_excluded_references("pinecone-n8n\n", {"include": SLUGS}, SLUGS) == []
+
+
 class TestFileDispatch:
     def test_py_gets_source_tag_only_not_cross_refs(self):
         text = '# see pinecone-assistant\nsource_tag="pinecone_skills:cli"\n'


### PR DESCRIPTION
> **Draft.** Three design questions at the bottom need a maintainer's call, and the rollout touches `PLUGIN_SYNC_PAT`, which only a maintainer can do.

## Summary

The Gemini CLI extension and the Codex plugin carry hand-copied versions of the skills in this repo and are not sync targets. They have drifted, and two of the drifts are user-facing breakage today. This PR adds them as targets: two manifests, two matrix entries gated behind an `enabled` flag, two small build-tool additions with tests, and README updates. No target repo is touched until someone dispatches the sync by name.

## What hand-copying has cost

| Problem | Gemini | Codex | Claude / Cursor |
|---|---|---|---|
| Assistant scripts use the SDK 8 API. `pinecone>=8.0.0` now resolves to 10.0.0, so `chat.py` fails at import with `ModuleNotFoundError: No module named 'pinecone_plugins'`. Five of six scripts are affected. | Broken | Broken | Fixed 2026-06 (claude-code-plugin#37) |
| Full-text-search skill targets `pinecone.preview`, deleted in SDK 10. Pins `pinecone==9.0.0`. | Not shipped | One SDK major behind (about 600 changed lines) | Fixed 2026-09-03 |
| Scripts advertise `/pinecone:assistant-upload` and similar slash commands that do not exist in the product. | 13 occurrences | 13 occurrences | Fixed via manifest snippets |
| `agentic-ide-source` stamped on assistants the plugin creates. | `gemini-cli` | `claude-code-plugin` (misattributed) | Correct |
| Pinecone CLI install command points at a Homebrew formula disabled 2026-03-30. | Stale | Stale | Stale, fixed in #33 and the plugin PRs |
| Retired agent-based `contextualize` workflow still present, gated on `sync/skills-`, a branch name the new sync deliberately does not use. | Present, dead | Present, dead | Removed 2026-08-12 |

This is the pattern `targets/README.md` already describes: a target that adapts skills by hand or by agent gives a different answer and stops getting fixes.

## What is in the diff

- `targets/gemini-cli.yaml`, `targets/codex.yaml`: derived from the live repos on 2026-09-09. Every departure from the live state is explained in a comment.
- `skills/pinecone-help/SKILL.md`: the two optional skills' table rows and routing lines, and the MCP row's third cell, become markers. Targets that ship a skill fill the row with the base text; targets that do not fill it with `""`, which removes the line. Claude Code and Cursor output is byte-identical to before this PR (checked by diffing `dist/`).
- `tools/build.py`:
  - `drop_frontmatter`, an optional manifest key so Gemini can strip `argument-hint`. `name` and `description` are refused, and a key may not be both added per slug and dropped.
  - An empty snippet on a marker-only line removes the line.
  - `check_excluded_references`: the build fails on any rendered reference to a `pinecone-<slug>` outside `include`. This is the guard that would have caught the help-table problem.
  - Manifest validation split into `validate_manifest` so it is testable.
- `.github/workflows/sync-skills.yml`: two matrix entries and two dispatch options. Matrix entries gain `enabled`; the `all` dispatch skips targets not yet enabled, so a routine run cannot open a migration PR nobody asked for or fail on a repo the PAT cannot write to. Selecting a target by name still works, including `dry_run`. The new targets start disabled.
- `targets/README.md`: the new field, the empty-snippet and no-overlap rules, verification item 4, and a "Known deltas" section for both targets.

## Verification

| Check | Result |
|---|---|
| `uv run tools/test_build.py` | 68 passed |
| `uv run tools/build.py --all --check` with four targets | All checks passed, including the new excluded-reference check |
| `dist/claude-code` and `dist/cursor` before vs after this PR | Byte-identical |
| Gemini render of `help` | Seven rows, no full-text-search or n8n, MCP row says the server is bundled |
| Gemini render of `cli` and `query` | No `argument-hint`; Codex render keeps it |
| Codex `scripts/check_all.py` against the rendered tree | 6 of 6 validators pass |
| `reconcile.py --target gemini-cli` vs live `main` | 17 discrepancies: 2 missing, 3 extra, 12 differ |
| `reconcile.py --target codex` vs live `main` | 18 discrepancies, all differ |
| `uv run skills/assistant/scripts/chat.py --help` in the live Gemini repo | `ModuleNotFoundError: No module named 'pinecone_plugins'` |

Every discrepancy is one of the drifts in the table, the CLI fix, or snippet wording. Nothing in either live repo is ahead of base.

## Changed in response to review (second commit)

- Help skill no longer advertises skills a target does not ship; excluded-reference check added.
- Gemini's "MCP server already installed" line is preserved via a marker instead of being overwritten.
- Codex invocation corrected to `$pinecone:<skill-name>`; Codex namespaces plugin skills and matches exactly, so the live README's `$<skill>` is wrong.
- Gemini API-key wording names `gemini extensions config pinecone`; extensions do not inherit the shell, so the export alone cannot fix MCP.
- Add-and-drop of the same frontmatter key is refused; validation has tests for every error path.
- `enabled` flag on matrix entries; stale README and workflow comments corrected.

## Open design questions

1. **Is `drop_frontmatter` the right mechanism?** `argument-hint` is not in the Agent Skills spec; `allowed-tools` is. The neutrality pass handled `allowed-tools` by removing it from base and adding it per target via `frontmatter:`. Doing the same for `argument-hint` would delete this key, its validation, and its tests. The cost is that Cursor's rendered `cli` and `query` lose the hint, which Cursor does not document. I lean toward that trade but did not make it unasked, since it changes Cursor's output.
2. **`pinecone-docs` in Gemini.** `dir_name` is one template, so the render produces `docs/`. The extension's `GEMINI.md` skill table and README reference `pinecone-docs` and live outside `skills_path`, so the sync cannot update them. Either land that rename in gemini-cli-extension before the first sync (my preference, and consistent with the point above about not adding knobs), or add a per-slug name override here.
3. **Seven snippets are byte-identical across cursor, gemini-cli, and codex.** Nothing enforces that. A shared defaults file, or an equality assertion in `check_snippets`, would stop them drifting the way the plugins did.

## Rollout after merge

1. Extend `PLUGIN_SYNC_PAT` to write on `gemini-cli-extension` and `pinecone-codex-plugin`.
2. Dispatch each new target by name with `dry_run: true` and read the reconcile report in the step summary.
3. Dispatch by name for real. Review each first sync PR as content; it is the migration.
4. In each target repo: delete the dead `contextualize` workflow, and in Gemini rename `pinecone-docs` to `docs` in `GEMINI.md` and README.
5. Flip `enabled: true` for each target once its first sync is merged.

## Related

- #33 fixes the CLI install command in base. The first sync from this PR carries that fix into both new targets.
- The two repos' own READMEs are not sync-managed; gemini-cli-extension#22 and pinecone-codex-plugin#3 fix the install command there.
